### PR TITLE
auto fix stary tags in tag tree and chenge arrow keys behavior when using inputs

### DIFF
--- a/src/frontend/components/ScoreEditor.tsx
+++ b/src/frontend/components/ScoreEditor.tsx
@@ -17,6 +17,7 @@ import { FloatingPanel } from '../containers/AppToolbar/FileTagEditor';
 import { ToolbarButton } from 'widgets/toolbar';
 import { IAction } from '../containers/types';
 import { ID } from 'src/api/id';
+import { useGalleryInputKeydownHandler } from '../hooks/useHandleInputKeydown';
 
 export const FloatingScoreEditor = observer(() => {
   const { uiStore } = useStore();
@@ -321,24 +322,7 @@ const ScoreListEditor = observer(
     const { uiStore } = useStore();
     const scores = Array.from(counter.get()).sort(compareByScoreName);
     const SelectionSize = uiStore.fileSelection.size;
-    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Backspace') {
-        // Prevent backspace from navigating back to main view when having an image open
-        e.stopPropagation();
-      }
-
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        // If shift key is pressed with arrow keys left/right,
-        // stop those key events from propagating to the gallery,
-        // so that the cursor in the text input can be moved without selecting the prev/next image
-        // Kind of an ugly work-around, but better than not being able to move the cursor at all
-        if (!e.altKey) {
-          e.stopPropagation(); // move text cursor as expected (and select text because shift is pressed)
-        } else {
-          e.preventDefault(); // don't do anything here: let the event propagate to the gallery
-        }
-      }
-    }, []);
+    const handleKeyDown = useGalleryInputKeydownHandler();
     const handleRename = useCallback(
       (score: ClientScore) => dispatch(Factory.enableEditing(score.id)),
       [dispatch],

--- a/src/frontend/components/ScoreSelector.tsx
+++ b/src/frontend/components/ScoreSelector.tsx
@@ -14,6 +14,7 @@ import { useStore } from '../contexts/StoreContext';
 import { computed, IComputedValue, runInAction } from 'mobx';
 import { IconSet } from 'widgets/icons';
 import { debounce } from 'common/timeout';
+import { useGalleryInputKeydownHandler } from '../hooks/useHandleInputKeydown';
 
 interface IScoreSelectorProps {
   counter?: IComputedValue<Map<ClientScore, [number, number | undefined]>>;
@@ -42,30 +43,18 @@ export const ScoreSelector = (props: IScoreSelectorProps) => {
     inputRef.current?.focus();
   }).current;
 
+  const baseHandleKeyDown = useGalleryInputKeydownHandler();
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Backspace') {
-        // Prevent backspace from navigating back to main view when having an image open
-        e.stopPropagation();
-      }
-
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        // If shift key is pressed with arrow keys left/right,
-        // stop those key events from propagating to the gallery,
-        // so that the cursor in the text input can be moved without selecting the prev/next image
-        // Kind of an ugly work-around, but better than not being able to move the cursor at all
-        if (e.shiftKey) {
-          e.stopPropagation(); // move text cursor as expected (and select text because shift is pressed)
-        } else {
-          e.preventDefault(); // don't do anything here: let the event propagate to the gallery
-        }
-      } else if (e.key === 'Escape') {
+      if (e.key === 'Escape') {
         e.preventDefault();
         setInputText('');
+      } else {
+        baseHandleKeyDown(e);
       }
       handleGridFocus(e);
     },
-    [handleGridFocus],
+    [baseHandleKeyDown, handleGridFocus],
   );
 
   const handleBlur = useRef((e: React.FocusEvent<HTMLDivElement>) => {

--- a/src/frontend/components/TagSelector.tsx
+++ b/src/frontend/components/TagSelector.tsx
@@ -18,6 +18,7 @@ import { useStore } from '../contexts/StoreContext';
 import { ClientTag } from '../entities/Tag';
 import { useComputed } from '../hooks/mobx';
 import { debounce } from 'common/timeout';
+import { useGalleryInputKeydownHandler } from '../hooks/useHandleInputKeydown';
 
 export interface TagSelectorProps {
   selection: ClientTag[];
@@ -60,7 +61,7 @@ const TagSelector = (props: TagSelectorProps) => {
   const [query, setQuery] = useState('');
   const [dobuncedQuery, setDebQuery] = useState('');
 
-  const debounceSetDebQuery = useRef(debounce(setDebQuery)).current;
+  const debounceSetDebQuery = useRef(debounce(setDebQuery, 500)).current;
   useEffect(() => {
     if (query.length > 2) {
       setDebQuery(query);
@@ -87,6 +88,7 @@ const TagSelector = (props: TagSelectorProps) => {
 
   const gridRef = useRef<HTMLDivElement>(null);
   const [activeDescendant, handleGridFocus] = useGridFocus(gridRef);
+  const handleGalleryInput = useGalleryInputKeydownHandler();
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Backspace') {
@@ -101,10 +103,11 @@ const TagSelector = (props: TagSelectorProps) => {
         setQuery('');
         setIsOpen(false);
       } else {
+        handleGalleryInput(e);
         handleGridFocus(e);
       }
     },
-    [handleGridFocus, onDeselect, isInputEmpty, selection],
+    [handleGridFocus, onDeselect, isInputEmpty, selection, handleGalleryInput],
   );
 
   const handleBlur = useRef((e: React.FocusEvent<HTMLDivElement>) => {

--- a/src/frontend/containers/AppToolbar/FileTagEditor.tsx
+++ b/src/frontend/containers/AppToolbar/FileTagEditor.tsx
@@ -23,6 +23,7 @@ import FocusManager from '../../FocusManager';
 import { useAction, useAutorun, useComputed } from '../../hooks/mobx';
 import { Menu, useContextMenu } from 'widgets/menus';
 import { EditorTagSummaryItems } from '../ContentView/menu-items';
+import { useGalleryInputKeydownHandler } from 'src/frontend/hooks/useHandleInputKeydown';
 
 const POPUP_ID = 'tag-editor-popup';
 
@@ -55,7 +56,7 @@ const TagEditor = observer(() => {
   const [inputText, setInputText] = useState('');
   const [dobuncedQuery, setDebQuery] = useState('');
 
-  const debounceSetDebQuery = useRef(debounce(setDebQuery)).current;
+  const debounceSetDebQuery = useRef(debounce(setDebQuery, 500)).current;
   useEffect(() => {
     if (inputText.length > 2) {
       setDebQuery(inputText);
@@ -133,27 +134,13 @@ const TagEditor = observer(() => {
     inputRef.current?.focus();
   });
 
+  const baseHandleKeydown = useGalleryInputKeydownHandler();
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Backspace') {
-        // Prevent backspace from navigating back to main view when having an image open
-        e.stopPropagation();
-      }
-
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        // If shift key is pressed with arrow keys left/right,
-        // stop those key events from propagating to the gallery,
-        // so that the cursor in the text input can be moved without selecting the prev/next image
-        // Kind of an ugly work-around, but better than not being able to move the cursor at all
-        if (e.shiftKey) {
-          e.stopPropagation(); // move text cursor as expected (and select text because shift is pressed)
-        } else {
-          e.preventDefault(); // don't do anything here: let the event propagate to the gallery
-        }
-      }
+      baseHandleKeydown(e);
       handleGridFocus(e);
     },
-    [handleGridFocus],
+    [baseHandleKeydown, handleGridFocus],
   );
 
   const handleTagContextMenu = TagSummaryMenu({ parentPopoverId: 'tag-editor' });

--- a/src/frontend/containers/HelpCenter.tsx
+++ b/src/frontend/containers/HelpCenter.tsx
@@ -368,10 +368,10 @@ const PAGE_DATA: () => IPageData[] = () => [
           <>
             <p>
               You can set implied relationships to a tag through the tag's contextual menu option
-              "Modify implied tags." When you tag a file, it also inherits all its ancestor and
-              implied tags, and inherits those from them too, automatically, to be used in search.
-              For example, if the tag dog implies mammal, and mammal implies animal, if you search
-              for animal, the dog will also be included because of the implied relationship.
+              "Modify implied tags". When you tag a file, it also inherits all its ancestor tags and
+              implied tags and inherits those from them too automatically, to be used in search. For
+              example, if the tag dog implies mammal, and mammal implies animal, if you search for
+              animal, files with tag dog will also be included because of the implied relationship.
             </p>
             <p>
               Inherited tags can't be removed from a file unless you remove all the tags that cause
@@ -392,7 +392,7 @@ const PAGE_DATA: () => IPageData[] = () => [
             <p>
               There are several ways to tag an image. First, you can drag a tag from the outliner
               onto an image. This also works on a selection of multiple images. Next, you can select
-              an image, press T to open the tag editor, and assign or remove tags from the list.
+              an image, press 3 to open the tag editor, and assign or remove tags from the list.
               This method also allows you to tag multiple images at once. Finally, you can add tags
               by adding them to the list in the inspector panel - the sidebar on the right when
               viewing images at at full size.
@@ -401,6 +401,10 @@ const PAGE_DATA: () => IPageData[] = () => [
               To remove tags from one or more images, you have to access either the tag editor or
               the inspector. In both places you will be able to remove individual tags or clear the
               entire set of tags on the selected image(s).
+            </p>
+            <p>
+              When using the tag editor, you can hold ALT + arrow keys to navigate through the
+              gallery items while keeping focus on the tag editor.
             </p>
           </>
         ),

--- a/src/frontend/hooks/useHandleInputKeydown.ts
+++ b/src/frontend/hooks/useHandleInputKeydown.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+
+// A custom hook that returns a memoized callback to handle keydown events on
+// input elements, preventing interference from gallery navigation keyboard
+// shortcuts while allowing navigation when the Alt key is pressed.
+export function useGalleryInputKeydownHandler() {
+  return useCallback((e: React.KeyboardEvent) => {
+    // Allow gallery navigation with Alt + Arrow keys, even when the input is focused.
+    if (e.altKey) {
+      e.preventDefault();
+      return;
+    }
+    // if Alt is not pressed, stop propagation to keep focus on the selected item.
+
+    switch (e.key) {
+      // Prevent backspace from navigating back to main view when having an image open
+      case 'Backspace':
+      // move text cursor as expected
+      case 'ArrowLeft':
+      case 'ArrowRight': {
+        e.stopPropagation(); //Prevent event to propagate to the gallery
+        break;
+      }
+      default:
+        break;
+    }
+  }, []);
+}

--- a/widgets/combobox/Grid.tsx
+++ b/widgets/combobox/Grid.tsx
@@ -30,6 +30,10 @@ export function useGridFocus(
     if (gridRef.current === null || gridRef.current.childElementCount === 0) {
       return;
     }
+    if (event.altKey) {
+      event.preventDefault();
+      return;
+    }
 
     const scrollOpts: ScrollIntoViewOptions = { block: 'nearest' };
     const options = gridRef.current.querySelectorAll(


### PR DESCRIPTION
- Ensure all tags are connected to the main tree by inserting stray tags under root on startup.
- Arrow key combinations behave normally when using an input. Hold ALT to navigate the gallery with arrow keys while keeping focus on the input.
