### PR TITLE
Feature/recent used tags

### DIFF
--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -576,7 +576,7 @@
   background-color: transparent;
   overflow: hidden;
   transition: opacity 0.3s ease;
-  z-index: 10;
+  z-index: 1;
 
   &.hidden {
     opacity: 0;

--- a/resources/style/controls/combobox.scss
+++ b/resources/style/controls/combobox.scss
@@ -29,9 +29,24 @@
 // Options
 [role='combobox'] {
   [role='separator'] {
-    background: var(--text-color-muted);
-    height: 1px;
-    margin: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    padding: 0.5rem 1rem;
+    width: -webkit-fill-available;
+
+    &::before,
+    &::after {
+      content: '';
+      flex: 1;
+      border-bottom: 1px solid var(--text-color-muted);
+    }
+
+    .separator-label {
+      margin: 0 0.5rem;
+      color: var(--text-color-muted);
+      white-space: nowrap;
+    }
   }
 
   // Option Groups

--- a/resources/style/controls/menu.scss
+++ b/resources/style/controls/menu.scss
@@ -6,9 +6,18 @@
   overflow: hidden auto;
 
   [role='separator'] {
-    background: var(--text-color-muted);
-    height: 1px;
-    margin: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    padding: 0.5rem 1rem;
+    width: -webkit-fill-available;
+
+    &::before,
+    &::after {
+      content: '';
+      flex: 1;
+      border-bottom: 1px solid var(--text-color-muted);
+    }
   }
 
   [role='group'] {
@@ -67,10 +76,19 @@ a[role='menuitem'] {
 }
 
 [role='menu'] [role='separator'] {
-  background: var(--text-color-muted);
-  height: 1px;
-  margin: 0.5rem 1rem;
   list-style: none;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  padding: 0.5rem 1rem;
+  width: -webkit-fill-available;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    border-bottom: 1px solid var(--text-color-muted);
+  }
 }
 
 .item-icon,

--- a/resources/style/controls/popover.scss
+++ b/resources/style/controls/popover.scss
@@ -115,7 +115,7 @@ dialog[role='alertdialog'] {
 // DIALOG UNTIL HERE
 
 [data-popover] {
-  z-index: 1;
+  z-index: 10;
 
   color: var(--text-color);
   background: var(--background-color-alt);

--- a/resources/style/extra-property-editor.scss
+++ b/resources/style/extra-property-editor.scss
@@ -53,9 +53,18 @@
     max-height: unset;
 
     [role='separator'] {
-      background: var(--text-color-muted);
-      height: 1px;
-      margin: 0.5rem 1rem;
+      display: flex;
+      align-items: center;
+      text-align: center;
+      padding: 0.5rem 1rem;
+      width: -webkit-fill-available;
+
+      &::before,
+      &::after {
+        content: '';
+        flex: 1;
+        border-bottom: 1px solid var(--text-color-muted);
+      }
     }
 
     .tag-option-hint {

--- a/resources/style/tag-editor.scss
+++ b/resources/style/tag-editor.scss
@@ -27,13 +27,6 @@
     border-top: 0.0625rem solid var(--border-color);
     max-width: unset;
     max-height: unset;
-
-    [role='separator'] {
-      background: var(--text-color-muted);
-      height: 1px;
-      margin: 0.5rem 1rem;
-      width: -webkit-fill-available;
-    }
   }
 
   .virtualized-grid {

--- a/src/frontend/containers/Settings/Shortcuts.tsx
+++ b/src/frontend/containers/Settings/Shortcuts.tsx
@@ -8,7 +8,7 @@ import { defaultHotkeyMap, IHotkeyMap } from '../../stores/UiStore';
 import { camelCaseToSpaced } from 'common/fmt';
 import { Button, IconSet, keyComboToString } from 'widgets';
 
-export const Shortcuts = observer(() => {
+export const Shortcuts = () => {
   return (
     <>
       <p>
@@ -18,7 +18,7 @@ export const Shortcuts = observer(() => {
       <HotkeyMapper />
     </>
   );
-});
+};
 
 export const HotkeyMapper = observer(() => {
   const { uiStore } = useStore();

--- a/src/frontend/containers/Settings/UsagePreferences.tsx
+++ b/src/frontend/containers/Settings/UsagePreferences.tsx
@@ -1,0 +1,40 @@
+import { observer } from 'mobx-react-lite';
+import React from 'react';
+import { useStore } from '../../contexts/StoreContext';
+import UiStore from 'src/frontend/stores/UiStore';
+
+export const UsagePreferences = () => {
+  return (
+    <>
+      <h3>Recently Used Tags</h3>
+
+      <div className="vstack">
+        <RecentTagsNumber />
+      </div>
+    </>
+  );
+};
+
+const RecentTagsNumber = observer(() => {
+  const { uiStore } = useStore();
+
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = Number(event.target.value);
+    uiStore.setRecentlyUsedTagsMaxLength(value);
+    // update recentlyUsedTags size
+    uiStore.addRecentlyUsedTag();
+  };
+
+  return (
+    <label>
+      Maximum number of recently used tags to remember
+      <select value={uiStore.recentlyUsedTagsMaxLength} onChange={handleChange}>
+        {[...Array(UiStore.MAX_RECENTLY_USED_TAGS + 1)].map((_, i) => (
+          <option key={i} value={i}>
+            {i}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+});

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -10,6 +10,7 @@ import { ImageFormatPicker } from './ImageFormatPicker';
 import { ImportExport } from './ImportExport';
 import { Shortcuts } from './Shortcuts';
 import { StartupBehavior } from './StartupBehavior';
+import { UsagePreferences } from './UsagePreferences';
 
 const Settings = () => {
   const { uiStore } = useStore();
@@ -44,6 +45,10 @@ const Tabs = () => {
     {
       label: 'Appearance',
       content: Appearance,
+    },
+    {
+      label: 'Usage Preferences',
+      content: UsagePreferences,
     },
     {
       label: 'Keyboard Shortcuts',

--- a/src/frontend/entities/File.ts
+++ b/src/frontend/entities/File.ts
@@ -152,6 +152,7 @@ export class ClientFile {
     const hasTag = this.tags.has(tag);
     if (!hasTag) {
       this.tags.add(tag);
+      this.store.addRecentlyUsedTag(tag);
       tag.incrementFileCount();
 
       if (this.tags.size === 1) {

--- a/src/frontend/entities/Tag.ts
+++ b/src/frontend/entities/Tag.ts
@@ -221,6 +221,14 @@ export class ClientTag {
     return Array.from(this.getAncestors(), (t) => t.name).reverse();
   }
 
+  @computed get pathCharLength(): number {
+    let total = 0;
+    for (let i = 0; i < this.path.length; i++) {
+      total += this.path[i].length;
+    }
+    return total;
+  }
+
   get isSelected(): boolean {
     return this.store.isSelected(this);
   }
@@ -344,6 +352,7 @@ export class ClientTag {
     for (const tag of newTags) {
       if (!this.impliedTags.includes(tag)) {
         this.addImpliedTag(tag);
+        this.store.addRecentlyUsedTag(tag);
       }
     }
   }
@@ -361,6 +370,7 @@ export class ClientTag {
     for (const tag of newTags) {
       if (!this._impliedByTags.includes(tag)) {
         tag.addImpliedTag(this);
+        this.store.addRecentlyUsedTag(tag);
       }
     }
   }

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -695,6 +695,10 @@ class FileStore {
     return this.rootStore.tagStore.getTags(ids);
   }
 
+  addRecentlyUsedTag(tag: ClientTag): void {
+    this.rootStore.uiStore.addRecentlyUsedTag(tag);
+  }
+
   getExtraProperties(
     dtoExtraProperties: ExtraProperties,
   ): Map<ClientExtraProperty, ExtraPropertyValue> {

--- a/src/frontend/stores/TagStore.ts
+++ b/src/frontend/stores/TagStore.ts
@@ -61,6 +61,10 @@ class TagStore {
     return tags;
   }
 
+  addRecentlyUsedTag(tag: ClientTag): void {
+    this.rootStore.uiStore.addRecentlyUsedTag(tag);
+  }
+
   @computed get root(): ClientTag {
     const root = this.tagGraph.get(ROOT_TAG_ID);
     if (!root) {


### PR DESCRIPTION
Implements RafaUC/Allusion#37
## Changes
- Add recentlyUsedTags and recentlyUsedTagsMaxLength as persistent preferences in UiStore, along with manipulation methods.
- Add a "Usage Preferences" submenu in settings with an option to configure the maximum number of recently used tags.
- Show recently used tags in tag selectors.
- Update the recently used tags list when performing an "add tag" action somewhere. Except for saved searches and creating an advanced search.
- Small bug fixes.