### PR TITLE
Feature/extra properties

### DIFF
--- a/resources/style/controls/input.scss
+++ b/resources/style/controls/input.scss
@@ -52,6 +52,14 @@
     height: unset;
     max-height: 100vh;
   }
+
+  &:disabled {
+    background-color: var(--background-color);
+  }
+
+  &:hover:disabled {
+    background-color: var(--background-color);
+  }
 }
 
 /** We cannot use <input type="file" /> as we want to pick directories. However,

--- a/src/api/data-storage-search.ts
+++ b/src/api/data-storage-search.ts
@@ -1,5 +1,3 @@
-import { OperatorType } from "./search-criteria";
-
 export type OrderBy<T> =
   | {
       [K in keyof T]: K extends string ? K : never;
@@ -32,7 +30,7 @@ export type DateConditionDTO<T> = BaseConditionDTO<T, NumberOperatorType, Date, 
 
 export type IndexSignatureConditionDTO<T, A> = BaseConditionDTO<
   T,
-  NumberOperatorType | StringOperatorType,
+  NumberOperatorType | StringOperatorType | ExtraPropertyOperatorType,
   [string, A],
   'indexSignature'
 >;
@@ -60,7 +58,7 @@ export const NumberOperators = [
   'greaterThan',
   'greaterThanOrEquals',
 ] as const;
-export type NumberOperatorType = typeof NumberOperators[number];
+export type NumberOperatorType = (typeof NumberOperators)[number];
 
 export const StringOperators = [
   'equalsIgnoreCase',
@@ -72,10 +70,17 @@ export const StringOperators = [
   'contains',
   'notContains',
 ] as const;
-export type StringOperatorType = typeof StringOperators[number];
+export type StringOperatorType = (typeof StringOperators)[number];
 
 export const ArrayOperators = ['contains', 'notContains'] as const;
-export type ArrayOperatorType = typeof ArrayOperators[number];
+export type ArrayOperatorType = (typeof ArrayOperators)[number];
+
+export const ExtraPropertyOperators = ['existsInFile', 'notExistsInFile'] as const;
+export type ExtraPropertyOperatorType = (typeof ExtraPropertyOperators)[number];
+
+export function isExtraPropertyOperatorType(op: string): op is ExtraPropertyOperatorType {
+  return ExtraPropertyOperators.includes(op as ExtraPropertyOperatorType);
+}
 
 export function isNumberOperator(op: string): op is NumberOperatorType {
   return NumberOperators.includes(op as NumberOperatorType);

--- a/src/api/search-criteria.ts
+++ b/src/api/search-criteria.ts
@@ -1,6 +1,10 @@
 import { ID } from './id';
 import { FileDTO } from './file';
-import { NumberOperatorType, StringOperatorType } from './data-storage-search';
+import {
+  ExtraPropertyOperatorType,
+  NumberOperatorType,
+  StringOperatorType,
+} from './data-storage-search';
 import { ExtraPropertyValue } from './extraProperty';
 
 export const BinaryOperators = ['equals', 'notEqual'] as const;
@@ -15,6 +19,7 @@ export const TagOperators = [
 export type TagOperatorType = (typeof TagOperators)[number];
 
 export type OperatorType =
+  | ExtraPropertyOperatorType
   | TagOperatorType
   | NumberOperatorType
   | StringOperatorType

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -12,6 +12,7 @@ import {
   OrderBy,
   OrderDirection,
   StringConditionDTO,
+  isExtraPropertyOperatorType,
   isNumberOperator,
   isStringOperator,
 } from '../api/data-storage-search';
@@ -678,6 +679,17 @@ function filterIndexSignatureLambda<T>(
     value: [keyIS, valueIS],
   } = crit;
 
+  if (isExtraPropertyOperatorType(crit.operator)) {
+    switch (crit.operator) {
+      case 'existsInFile':
+        return (t: any) => t[crit.key][keyIS] !== undefined;
+      case 'notExistsInFile':
+        return (t: any) => t[crit.key][keyIS] === undefined;
+      default:
+        const _exhaustiveCheck: never = crit.operator;
+        return _exhaustiveCheck;
+    }
+  }
   switch (typeof valueIS) {
     case 'number':
       if (isNumberOperator(crit.operator)) {

--- a/src/frontend/components/ExtraPropertySelector.tsx
+++ b/src/frontend/components/ExtraPropertySelector.tsx
@@ -113,6 +113,7 @@ export const ExtraPropertySelector = (props: IExtraPropertySelectorProps) => {
     >
       <input
         //disabled={disabled}
+        autoFocus
         role="menuitem"
         type="text"
         className={'input'}

--- a/src/frontend/components/TagSelector.tsx
+++ b/src/frontend/components/TagSelector.tsx
@@ -26,7 +26,6 @@ import { useComputed } from '../hooks/mobx';
 import { debounce } from 'common/timeout';
 import { useGalleryInputKeydownHandler } from '../hooks/useHandleInputKeydown';
 import { Placement } from '@floating-ui/core';
-import { CREATE_OPTION } from './FileTagsEditor';
 import { computed } from 'mobx';
 
 export interface TagSelectorProps {
@@ -165,7 +164,11 @@ const TagSelector = (props: TagSelectorProps) => {
 
   const handleFocus = useRef(() => setIsOpen(true)).current;
 
-  const handleBackgroundClick = useCallback(() => inputRef.current?.focus(), []);
+  const handleBackgroundClick = useCallback((e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).tagName !== 'INPUT') {
+      inputRef.current?.focus();
+    }
+  }, []);
 
   const resetTextBox = useRef(() => {
     inputRef.current?.focus();

--- a/src/frontend/components/TagSelector.tsx
+++ b/src/frontend/components/TagSelector.tsx
@@ -44,6 +44,7 @@ export interface TagSelectorProps {
   multiline?: boolean;
   filter?: (tag: ClientTag) => boolean;
   showTagContextMenu?: (e: React.MouseEvent<HTMLElement>, tag: ClientTag) => void;
+  ignoreOnBlur?: (e: React.FocusEvent) => boolean;
   suggestionsUpdateDependency?: number;
 }
 
@@ -54,6 +55,7 @@ const TagSelector = (props: TagSelectorProps) => {
     onDeselect,
     onTagClick,
     showTagContextMenu,
+    ignoreOnBlur,
     onClear,
     disabled,
     extraIconButtons,
@@ -150,7 +152,11 @@ const TagSelector = (props: TagSelectorProps) => {
       e.currentTarget.contains(e.relatedTarget) &&
       (e.relatedTarget.matches('div[role="row"]') ||
         e.relatedTarget.matches('div.virtualized-grid'));
-    if (isFocusingOption || e.relatedTarget === inputRef.current) {
+    if (
+      (ignoreOnBlur ? ignoreOnBlur(e) : false) ||
+      isFocusingOption ||
+      e.relatedTarget === inputRef.current
+    ) {
       return;
     }
     setQuery('');

--- a/src/frontend/containers/AdvancedSearch/CriteriaBuilder.tsx
+++ b/src/frontend/containers/AdvancedSearch/CriteriaBuilder.tsx
@@ -82,6 +82,7 @@ const CriteriaBuilder = memo(function QueryBuilder({ keySelector, dispatch }: Qu
           value={criteria.value}
           dispatch={setCriteria}
           extraProperty={extraProperty}
+          operator={criteria.operator}
         />
         <IconButton text="Add Criteria" icon={IconSet.ADD} onClick={add} />
       </div>

--- a/src/frontend/containers/AdvancedSearch/QueryEditor.tsx
+++ b/src/frontend/containers/AdvancedSearch/QueryEditor.tsx
@@ -125,6 +125,7 @@ export const EditableCriteria = ({ index, id, criteria, dispatch }: EditableCrit
           value={criteria.value}
           dispatch={setCriteria}
           extraProperty={extraProperty}
+          operator={criteria.operator}
         />
       </td>
       <td>

--- a/src/frontend/containers/AdvancedSearch/data.ts
+++ b/src/frontend/containers/AdvancedSearch/data.ts
@@ -1,5 +1,9 @@
 import { generateWidgetId } from 'widgets/utility';
-import { NumberOperatorType, StringOperatorType } from '../../../api/data-storage-search';
+import {
+  ExtraPropertyOperatorType,
+  NumberOperatorType,
+  StringOperatorType,
+} from '../../../api/data-storage-search';
 import { FileDTO, IMG_EXTENSIONS } from '../../../api/file';
 import { ID } from '../../../api/id';
 import { BinaryOperatorType, OperatorType, TagOperatorType } from '../../../api/search-criteria';
@@ -25,6 +29,7 @@ export type Criteria =
   | Field<'size', NumberOperatorType, number>
   | Field<'width' | 'height', NumberOperatorType, number>
   | Field<'dateAdded', NumberOperatorType, Date>
+  | ExtraPropertyField<ExtraPropertyID, ExtraPropertyOperatorType, any>
   | ExtraPropertyField<ExtraPropertyID, NumberOperatorType, number>
   | ExtraPropertyField<ExtraPropertyID, StringOperatorType, string>;
 

--- a/src/frontend/containers/AppToolbar/Searchbar.tsx
+++ b/src/frontend/containers/AppToolbar/Searchbar.tsx
@@ -209,6 +209,7 @@ const QuickExtraPropertySearchOption = (props: QuickEPOption) => {
         }}
       />
       {portalRoot &&
+        // Need to use portals since popovers don't work inside containers that have the transform property, which is used in virtualized grid.
         ReactDOM.createPortal(
           <div ref={reference}>
             {showExtraSelector && (

--- a/src/frontend/containers/ContentView/ContentProgressBar.tsx
+++ b/src/frontend/containers/ContentView/ContentProgressBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { observer } from 'mobx-react-lite';
 import ProgressBar from 'src/frontend/components/ProgressBar';
 import { useStore } from 'src/frontend/contexts/StoreContext';
@@ -14,12 +14,17 @@ const ContentProgressBar = observer(() => {
     showsMissingContent,
     showsAllContent,
     showsUntaggedContent,
+    fetchTaskIdPair,
   } = fileStore;
   let total: number;
 
   //** logic that includes the "FilesFromBackend" progress in the total and progress */
   if (showsQueryContent || showsMissingContent) {
-    if (numLoadedFiles > fileList.length || (numLoadedFiles === 0 && fileList.length > 0)) {
+    if (
+      fetchTaskIdPair[1] !== 0 ||
+      numLoadedFiles > fileList.length ||
+      (numLoadedFiles === 0 && fileList.length > 0)
+    ) {
       total = numTotalFiles;
     } else {
       total = fileList.length;
@@ -52,7 +57,7 @@ const ContentProgressBar = observer(() => {
       total={total}
       simulatedTotal={simulatedTotal}
       simulatedDurationMs={AverageTime}
-      simulatedResetKey={fileStore.fetchTaskIdPair[0]}
+      simulatedResetKey={fetchTaskIdPair[0]}
       height={'3px'}
     />
   );

--- a/src/frontend/entities/SearchCriteria.ts
+++ b/src/frontend/entities/SearchCriteria.ts
@@ -5,7 +5,9 @@ import {
   ArrayConditionDTO,
   ConditionDTO,
   DateConditionDTO,
+  ExtraPropertyOperatorType,
   IndexSignatureConditionDTO,
+  isExtraPropertyOperatorType,
   NumberConditionDTO,
   NumberOperatorType,
   StringConditionDTO,
@@ -53,6 +55,11 @@ export const StringOperatorLabels: Record<StringOperatorType, string> = {
   notStartsWith: 'Not Starts With',
   contains: 'Contains',
   notContains: 'Not Contains',
+};
+
+export const ExtraPropertyOperatorLabels: Record<ExtraPropertyOperatorType, string> = {
+  existsInFile: 'Exists in File',
+  notExistsInFile: 'Does Not Exist in File',
 };
 
 export abstract class ClientFileSearchCriteria implements IBaseSearchCriteria {
@@ -202,7 +209,9 @@ export class ClientExtraPropertySearchCriteria extends ClientFileSearchCriteria 
     const ep = rootStore.extraPropertyStore.get(this.value[0]);
     let operatorString = undefined;
     if (ep !== undefined) {
-      if (ep.type === epType.text) {
+      if (isExtraPropertyOperatorType(this.operator)) {
+        operatorString = ExtraPropertyOperatorLabels[this.operator as ExtraPropertyOperatorType];
+      } else if (ep.type === epType.text) {
         operatorString = StringOperatorLabels[this.operator as StringOperatorType];
       } else if (ep.type === epType.number) {
         operatorString = NumberOperatorSymbols[this.operator as NumberOperatorType];
@@ -210,14 +219,14 @@ export class ClientExtraPropertySearchCriteria extends ClientFileSearchCriteria 
     }
     return `EP: "${ep?.name || 'Invalid Property'}" ${
       operatorString || camelCaseToSpaced(this.operator)
-    } "${this.value[1]}"`;
+    } ${isExtraPropertyOperatorType(this.operator) ? '' : `"${this.value[1]}"`}`;
   };
 
   serialize = (): IExtraProperySearchCriteria => {
     return {
       key: this.key,
       valueType: this.valueType,
-      operator: this.operator as StringOperatorType | NumberOperatorType,
+      operator: this.operator,
       value: Array.from(this.value) as [string, ExtraPropertyValue],
     };
   };

--- a/src/frontend/hooks/useHandleInputKeydown.ts
+++ b/src/frontend/hooks/useHandleInputKeydown.ts
@@ -1,14 +1,48 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
+import { comboMatches, getKeyCombo, parseKeyCombo } from '../hotkeyParser';
+import { useStore } from '../contexts/StoreContext';
+import { action } from 'mobx';
 
 // A custom hook that returns a memoized callback to handle keydown events on
 // input elements, preventing interference from gallery navigation keyboard
 // shortcuts while allowing navigation when the Alt key is pressed.
 export function useGalleryInputKeydownHandler() {
+  const { uiStore } = useStore();
+
+  const procesGalleryInputShortcuts = useRef(
+    action((e: React.KeyboardEvent): boolean => {
+      const combo = getKeyCombo(e.nativeEvent);
+      const matches = (c: string): boolean => {
+        return comboMatches(combo, parseKeyCombo(c));
+      };
+      const { hotkeyMap } = uiStore;
+
+      if (matches(hotkeyMap.advancedSearch)) {
+        uiStore.toggleAdvancedSearch();
+      } else {
+        // If no shortcut matches, return false.
+        return false;
+      }
+      return true;
+    }),
+  ).current;
+
   return useCallback((e: React.KeyboardEvent) => {
     // Allow gallery navigation with Alt + Arrow keys, even when the input is focused.
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+      if (procesGalleryInputShortcuts(e)) {
+        e.preventDefault();
+        return;
+      }
+    }
     if (e.altKey) {
       e.preventDefault();
       return;
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      if (e.target instanceof HTMLInputElement) {
+        e.target.blur();
+      }
     }
     // if Alt is not pressed, stop propagation to keep focus on the selected item.
     e.stopPropagation(); //Prevent event to propagate to the gallery

--- a/src/frontend/hooks/useHandleInputKeydown.ts
+++ b/src/frontend/hooks/useHandleInputKeydown.ts
@@ -29,11 +29,9 @@ export function useGalleryInputKeydownHandler() {
 
   return useCallback((e: React.KeyboardEvent) => {
     // Allow gallery navigation with Alt + Arrow keys, even when the input is focused.
-    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
-      if (procesGalleryInputShortcuts(e)) {
-        e.preventDefault();
-        return;
-      }
+    if (procesGalleryInputShortcuts(e)) {
+      e.preventDefault();
+      return;
     }
     if (e.altKey) {
       e.preventDefault();

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -323,7 +323,8 @@ class FileStore {
     const firstCiteria = this.rootStore.uiStore.searchCriteriaList[0] as
       | ClientFileSearchCriteria
       | undefined;
-    const condition = firstCiteria?.toCondition(this.rootStore);
+    const raw = firstCiteria?.toCondition(this.rootStore);
+    const condition = Array.isArray(raw) ? raw[1] ?? raw[0] : raw;
     if (condition !== undefined && this.content === Content.Query) {
       // If the condition type needs 'where' or 'lambda' filters mixed in,
       // the fetch time varies depending on the operator
@@ -621,7 +622,9 @@ class FileStore {
       return this.fetchAllFiles();
     }
 
-    const criterias = uiStore.searchCriteriaList.map((c) => c.toCondition(this.rootStore));
+    const criterias: ConditionDTO<FileDTO>[] = uiStore.searchCriteriaList.flatMap((c) =>
+      c.toCondition(this.rootStore),
+    );
     try {
       this.setContentQuery();
       // Indicate a new fetch process

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -456,6 +456,7 @@ class FileStore {
     this.numLoadedFiles = 0;
     const now = performance.now();
     this.fetchTaskIdPair[0] = now;
+    this.fetchTaskIdPair[1] = 1;
     return now;
   }
 
@@ -816,6 +817,7 @@ class FileStore {
     if (backendFiles.length === 0) {
       this.rootStore.uiStore.clearFileSelection();
       this.fileListLastModified = new Date();
+      this.fetchTaskIdPair[1] = 0;
       return this.clearFileList();
     }
 
@@ -1036,6 +1038,10 @@ class FileStore {
         if (file && !reusedStatus.has(file.id)) {
           file.dispose();
         }
+      }
+      // set task sub id as finished if not aborted
+      if (status.valueOf() !== Status.aborted) {
+        this.fetchTaskIdPair[1] = 0;
       }
     });
     return { newFiles: targetList, newIndex: targeIndex, status: status };

--- a/src/frontend/stores/RootStore.ts
+++ b/src/frontend/stores/RootStore.ts
@@ -98,10 +98,10 @@ class RootStore {
     const fileStoreInit =
       numCriterias === 0
         ? rootStore.fileStore.fetchAllFiles
-        : () => {
+        : async () => {
             // When searching by criteria, the file counts won't be set (only when fetching all files),
             // so fetch them manually
-            rootStore.fileStore.refetchFileCounts().catch(console.error);
+            await rootStore.fileStore.refetchFileCounts().catch(console.error);
             return rootStore.fileStore.fetchFilesByQuery();
           };
 

--- a/src/frontend/stores/RootStore.ts
+++ b/src/frontend/stores/RootStore.ts
@@ -1,4 +1,4 @@
-import { configure, runInAction } from 'mobx';
+import { configure, reaction, runInAction } from 'mobx';
 
 import { DataStorage } from 'src/api/data-storage';
 import { DataBackup } from 'src/api/data-backup';
@@ -108,13 +108,22 @@ class RootStore {
     // Load the files already in the database so user instantly sees their images
     fileStoreInit().then(() => {
       rootStore.tagStore.initializeFileCounts(rootStore.fileStore.fileList);
-
-      // If slide mode was recovered from previous session, it's disabled by setContentQuery :/
-      // hacky workaround
-      if (isSlideMode) {
-        rootStore.uiStore.enableSlideMode();
-      }
     });
+
+    // If slide mode was recovered from a previous session, it was disabled by setContentQuery.
+    // Watch fileStore.numLoadedFiles until there are files in view to re-enable slide mode.
+    if (isSlideMode) {
+      const disposer = reaction(
+        () => rootStore.fileStore.numLoadedFiles,
+        (numLoadedFiles) => {
+          if (numLoadedFiles > 0) {
+            rootStore.uiStore.enableSlideMode();
+            // Dispose the reaction in the next tick
+            setTimeout(disposer, 0);
+          }
+        },
+      );
+    }
 
     // Then, look for any new or removed images, and refetch if necessary
     rootStore.locationStore.watchLocations().then((foundNewFiles) => {


### PR DESCRIPTION
## More Extra Properties Features
* Feature - add the ability to filter files based on whether they have an extra property or not. RafaUC/Allusion#53
* Feature - Add a quick create extra property criteria option in the Searchbar's create options. RafaUC/Allusion#53
* Feature - Add a toggle to directly open the "create option" alternative menu in the Tag selector and search bar by pressing the Alt key.

* Optimization - Speed up certain extraProperty criterias by adding an array condition to filter files using where before filter using indexSignature.

* Fix - ContentProgressBar not showing properly in query fetches when the file list is empty.
* Fix - Backend.countFiles did not count untagged files correctly. If man y files had many tags, the untagged count could result in a high negative number.
* Fix - Recovering slide mode at startup as soon as files are available in view. Previously, it waited until the initial fetch resolved.