### PR TITLE
Ux improvements

### DIFF
--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -468,7 +468,7 @@
     }
 
     // Note: this feature has an ugly exception, when filename is also shown. See the #gallery-item[data-show-overlay] rule below
-    &:hover .thumbnail-tags {
+    .thumbnail-tags:hover {
       max-height: 100%;
       overflow-y: overlay; // overlay scrollbar so it doesn't push tags away
 
@@ -490,7 +490,7 @@
       bottom: 0;
       overflow: hidden;
       transition: 0.25s $pt-transition-cubic2;
-      max-height: 2.8em;
+      max-height: 2.5em;
       max-width: 100%;
 
       // Allow dragging of images to elsewhere here too, just like the .thumbnail itself (drag-export)
@@ -562,7 +562,7 @@
 // move the tags up by the height of the filename element (23.59px)
 #gallery-content[data-show-overlay='true'] .masonry {
   [data-masonrycell] {
-    &:hover .thumbnail-tags {
+    .thumbnail-tags:hover  {
       max-height: calc(100% - 1.5em - 0.25rem);
     }
   }

--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -535,12 +535,16 @@
     &:hover {
       .thumbnail-overlay {
         background-color: rgba(0, 0, 0, .75);
+        // Allow text selection around the name for better ux
+        user-select: text;
 
         &:hover {
           // Expand filename on hover if it was truncated
           > :first-child {
             overflow: inherit;
             text-overflow: inherit;
+            // Allow text selection
+            user-select: text;
           }
         }
       }

--- a/resources/style/controls/combobox.scss
+++ b/resources/style/controls/combobox.scss
@@ -89,15 +89,21 @@
     }
 
     &[aria-selected='false']::before {
-      background-color: var(--text-color-muted);
       mask-image: url(~resources/icons/select-all.svg);
       -webkit-mask-image: url(~resources/icons/select-all.svg);
     }
 
     &[aria-selected='true']::before {
-      background-color: var(--text-color);
       mask-image: url(~resources/icons/select-all-checked.svg);
       -webkit-mask-image: url(~resources/icons/select-all-checked.svg);
+    }
+
+    &[data-highlight-check="false"]::before {
+      background-color: var(--text-color-muted);
+    }
+
+    &[data-highlight-check="true"]::before {
+      background-color: var(--text-color);
     }
 
     &:not([aria-selected])::before {

--- a/resources/style/tag-editor.scss
+++ b/resources/style/tag-editor.scss
@@ -70,12 +70,3 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
-
-[role='row'].tag-option {
-  &:not([aria-selected])::before {
-    display: initial;
-    background-color: var(--text-color-muted);
-    mask-image: url(~resources/icons/select-all-checked.svg);
-    -webkit-mask-image: url(~resources/icons/select-all-checked.svg);
-  }
-}

--- a/src/frontend/components/FileTagsEditor.tsx
+++ b/src/frontend/components/FileTagsEditor.tsx
@@ -17,6 +17,7 @@ import {
   createGetTabMatchTagCallback,
   createTagRowRenderer,
   GetTabMatchTag,
+  isTagSelected,
   useTabTagAutocomplete,
 } from './TagSelector';
 import { useStore } from '../contexts/StoreContext';
@@ -347,14 +348,14 @@ const MatchingTagsList = observer(
       [resetTextBox],
     );
 
-    const isSelected = useCallback(
+    const isSelected: isTagSelected = useCallback(
       // If all selected files have the tag mark it as selected,
       // else if partially in selected files return undefined, else mark it as not selected.
       (tag: ClientTag) => {
         const tagRecord = counter.get().get(tag);
         const isExplicit = tagRecord?.[1] ?? false;
         const isPartial = tagRecord?.[0] !== uiStore.fileSelection.size;
-        return isExplicit ? (isPartial ? undefined : true) : false;
+        return [tagRecord !== undefined && !isPartial, isExplicit];
       },
       [counter, uiStore],
     );

--- a/src/frontend/components/Toaster.tsx
+++ b/src/frontend/components/Toaster.tsx
@@ -1,6 +1,6 @@
 import { action, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react-lite';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Button } from 'widgets/button';
 import { Toast } from 'widgets/notifications';
@@ -87,8 +87,30 @@ export const Toaster = observer(() => (
 ));
 
 const SavingIndicator = observer(() => {
+  const [isInLayout, setIsInLayout] = useState(false);
   const {
     fileStore: { isSaving },
   } = useStore();
-  return <>{isSaving && <div className="saving-indicator"></div>}</>;
+
+  // Remove from layout with a delay to avoid annoying layout jumps in toasts
+  useEffect(() => {
+    const timeout = setTimeout(
+      () => {
+        setIsInLayout(isSaving);
+      },
+      isSaving ? 0 : 800,
+    );
+    return () => clearTimeout(timeout);
+  }, [isSaving]);
+
+  return (
+    <>
+      {isInLayout && (
+        <div
+          className="saving-indicator"
+          style={isSaving ? undefined : { visibility: 'hidden' }}
+        ></div>
+      )}
+    </>
+  );
 });

--- a/src/frontend/containers/ContentView/GalleryItem.tsx
+++ b/src/frontend/containers/ContentView/GalleryItem.tsx
@@ -5,15 +5,15 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { ellipsize, humanFileSize } from 'common/fmt';
 import { encodeFilePath, isFileExtensionVideo } from 'common/fs';
-import { IconButton, IconSet, Tag } from 'widgets';
+import { IconButton, IconSet } from 'widgets';
 import { useStore } from '../../contexts/StoreContext';
 import { ClientFile } from '../../entities/File';
-import { ClientTag } from '../../entities/Tag';
 import { usePromise } from '../../hooks/usePromise';
-import { CommandDispatcher, MousePointerEvent } from './Commands';
+import { CommandDispatcher } from './Commands';
 import { ITransform } from './Masonry/layout-helpers';
 import { GalleryVideoPlaybackMode } from 'src/frontend/stores/UiStore';
 import { thumbnailMaxSize } from 'common/config';
+import { IncrementalTagItems } from 'src/frontend/components/FileTagsEditor';
 
 interface ItemProps {
   file: ClientFile;
@@ -306,14 +306,16 @@ export const ThumbnailTags = observer(
         onDrop={eventManager.drop}
         onDragEnd={eventManager.dragEnd}
       >
-        {file.sortedInheritedTags.map((tag) => (
-          <TagWithHint key={tag.id} tag={tag} onContextMenu={eventManager.showTagContextMenu} />
-        ))}
+        <IncrementalTagItems
+          tags={file.sortedInheritedTags}
+          onContextMenu={eventManager.showTagContextMenu}
+        />
       </span>
     );
   },
 );
 
+/*
 const TagWithHint = observer(
   ({
     tag,
@@ -335,6 +337,7 @@ const TagWithHint = observer(
     );
   },
 );
+*/
 
 const ThumbnailOverlay = ({
   file,

--- a/src/frontend/containers/ContentView/GalleryItem.tsx
+++ b/src/frontend/containers/ContentView/GalleryItem.tsx
@@ -350,7 +350,7 @@ const ThumbnailOverlay = ({
   }, ${humanFileSize(file.size)}`;
 
   return (
-    <div className="thumbnail-overlay" data-tooltip={title}>
+    <div className="thumbnail-overlay" data-tooltip={title} tabIndex={-1} onBlur={deselect}>
       {showFilename && (
         <div className="thumbnail-filename" data-tooltip={title}>
           {file.name}
@@ -364,4 +364,11 @@ const ThumbnailOverlay = ({
       )}
     </div>
   );
+};
+
+const deselect = () => {
+  const selection = window.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+  }
 };

--- a/src/frontend/containers/ContentView/Masonry/MasonryWorkerAdapter.tsx
+++ b/src/frontend/containers/ContentView/Masonry/MasonryWorkerAdapter.tsx
@@ -24,11 +24,11 @@ export class MasonryWorkerAdapter implements Layouter {
   private prevNumImgs: number = 0;
 
   async initialize(numItems: number) {
-    this.prevNumImgs = numItems;
-
     if (this.memory !== undefined && this.worker !== undefined) {
       return;
     }
+
+    this.prevNumImgs = numItems;
 
     console.debug('initializing masonry worker...');
     const wasm = await init();

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -19,6 +19,7 @@ import { LocationTreeItemRevealer } from '../Outliner/LocationsPanel';
 import { TagsTreeItemRevealer } from '../Outliner/TagsPanel/TagsTree';
 import { ClientExtraProperty } from 'src/frontend/entities/ExtraProperty';
 import { isFileExtensionVideo } from 'common/fs';
+import { runInAction } from 'mobx';
 
 export const MissingFileMenuItems = observer(() => {
   const { uiStore, fileStore } = useStore();
@@ -37,7 +38,16 @@ export const MissingFileMenuItems = observer(() => {
 });
 
 export const FileViewerMenuItems = ({ file }: { file: ClientFile }) => {
-  const { uiStore, locationStore } = useStore();
+  const { uiStore, locationStore, fileStore } = useStore();
+
+  const handleClearSelectedFileTags = () => {
+    // Currently copy tags to clipboard as backup in case of error by the user
+    // ToDo: add a confirm dialog?
+    uiStore.copyTagsToClipboard();
+    runInAction(() => {
+      uiStore.fileSelection.forEach((f) => f.clearTags());
+    });
+  };
 
   const handleViewFullSize = () => {
     uiStore.selectFile(file, true);
@@ -81,7 +91,28 @@ export const FileViewerMenuItems = ({ file }: { file: ClientFile }) => {
         text="Open In Preview Window"
         icon={IconSet.PREVIEW}
       />
-      <MenuItem onClick={uiStore.openFileTagsEditor} text="Open Tag Selector" icon={IconSet.TAG} />
+      <MenuSubItem text="Tagging..." icon={IconSet.TAG_ADD}>
+        <MenuItem
+          onClick={uiStore.openFileTagsEditor}
+          text="Open Tag Selector"
+          icon={IconSet.TAG}
+        />
+        <MenuItem
+          onClick={fileStore.readTagsFromSelectedFiles}
+          text="Import Tags From Selected Files Metadata"
+          icon={IconSet.TAG_ADD}
+        />
+        <MenuItem
+          onClick={fileStore.writeTagsToSelectedFiles}
+          text="Overwrite Tags in Selected Files Metadata"
+          icon={IconSet.WARNING}
+        />
+        <MenuItem
+          onClick={handleClearSelectedFileTags}
+          text="Clear Selected Files Tags (and copy tags)"
+          icon={IconSet.TAG_BLANCO}
+        />
+      </MenuSubItem>
       <MenuItem onClick={uiStore.copyTagsToClipboard} text="Copy Tags" icon={IconSet.TAG_GROUP} />
       <MenuItem
         onClick={uiStore.pasteTags}

--- a/src/frontend/containers/Outliner/TagsPanel/TagMerge.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagMerge.tsx
@@ -1,23 +1,32 @@
 import { observer } from 'mobx-react-lite';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Button, IconSet, Tag } from 'widgets';
+import { Button, Checkbox, IconSet, Tag } from 'widgets';
 import { Dialog } from 'widgets/popovers';
 import { useStore } from '../../../contexts/StoreContext';
 import { ClientTag } from '../../../entities/Tag';
 import { Placement } from '@floating-ui/core';
 import { TagSelector } from 'src/frontend/components/TagSelector';
+import { Menu, MenuCheckboxItem } from 'widgets/menus';
 
 interface TagMergeProps {
   tag: ClientTag;
   onClose: () => void;
 }
 
+const ADD_AS_ALIAS_ID = 'merge-add-as-alias';
 const FALLBACK_PLACEMENTS: Placement[] = ['bottom'];
 
 /** this component is only shown when all tags in the context do not have child-tags */
 export const TagMerge = observer(({ tag, onClose }: TagMergeProps) => {
   const { tagStore, uiStore } = useStore();
+  const [addAsAliasEnabled, setAddAsAlias] = useState(
+    localStorage.getItem(ADD_AS_ALIAS_ID) == 'true',
+  );
+
+  useEffect(() => {
+    localStorage.setItem(ADD_AS_ALIAS_ID, JSON.stringify(addAsAliasEnabled));
+  }, [addAsAliasEnabled]);
 
   const ctxTags = uiStore.getTagContextItems(tag.id);
 
@@ -28,7 +37,7 @@ export const TagMerge = observer(({ tag, onClose }: TagMergeProps) => {
   const merge = () => {
     if (selectedTag !== undefined && !mergingWithSelf) {
       for (const ctxTag of ctxTags) {
-        tagStore.merge(ctxTag, selectedTag);
+        tagStore.merge(ctxTag, selectedTag, addAsAliasEnabled);
       }
       onClose();
     }
@@ -57,6 +66,12 @@ export const TagMerge = observer(({ tag, onClose }: TagMergeProps) => {
             ))}
           </div>
 
+          <br />
+          <MenuCheckboxItem
+            checked={addAsAliasEnabled}
+            onClick={() => setAddAsAlias(!addAsAliasEnabled)}
+            text={'Add merged tag as alias to the selected tag'}
+          />
           <br />
 
           <label className="dialog-label" htmlFor="tag-merge-picker">

--- a/src/frontend/entities/Tag.ts
+++ b/src/frontend/entities/Tag.ts
@@ -359,7 +359,9 @@ export class ClientTag {
   }
 
   @action.bound addAlias(alias: string): void {
-    this.aliases.push(alias);
+    if (!this.aliases.includes(alias)) {
+      this.aliases.push(alias);
+    }
   }
 
   @action.bound setAlias(alias: string, index: number): void {

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -107,10 +107,17 @@ class FileStore {
     // reaction to keep updated properties "related" to fileList
   }
 
-  @action.bound async readTagsFromFiles(): Promise<void> {
+  @action.bound async readTagsFromSelectedFiles(): Promise<void> {
+    return this.readTagsFromFiles(undefined, true);
+  }
+
+  @action.bound async readTagsFromFiles(_?: React.MouseEvent, onlySelected = false): Promise<void> {
     const toastKey = 'read-tags-from-file';
     try {
-      const numFiles = this.fileList.length;
+      const files = onlySelected
+        ? Array.from(this.rootStore.uiStore.fileSelection)
+        : this.fileList.slice();
+      const numFiles = files.length;
       for (let i = 0; i < numFiles; i++) {
         AppToaster.show(
           {
@@ -119,7 +126,7 @@ class FileStore {
           },
           toastKey,
         );
-        const file = runInAction(() => this.fileList[i]);
+        const file = files[i];
         if (!file) {
           continue;
         }
@@ -200,12 +207,19 @@ class FileStore {
     }
   }
 
-  @action.bound async writeTagsToFiles(): Promise<void> {
+  @action.bound async writeTagsToSelectedFiles(): Promise<void> {
+    return this.writeTagsToFiles(undefined, true);
+  }
+
+  @action.bound async writeTagsToFiles(_?: React.MouseEvent, onlySelected = false): Promise<void> {
     const toastKey = 'write-tags-to-file';
     try {
-      const numFiles = this.fileList.length;
+      const files = onlySelected
+        ? Array.from(this.rootStore.uiStore.fileSelection)
+        : this.definedFiles.slice();
+      const numFiles = files.length;
       const fileTagsProps = runInAction(() =>
-        this.definedFiles.map((f) => {
+        files.map((f) => {
           const extraProps: Record<string, ExtraPropertyValue> = {};
           for (const [ep, value] of f.extraProperties) {
             extraProps[ep.name] = value;

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -1075,7 +1075,7 @@ class UiStore {
     if (this.searchCriteriaList.length > 0) {
       this.searchCriteriaList.forEach((c) => c.dispose());
       this.searchCriteriaList.clear();
-      this.viewAllContent();
+      //this.viewAllContent();
     }
   }
 

--- a/widgets/combobox/Grid.tsx
+++ b/widgets/combobox/Grid.tsx
@@ -407,6 +407,7 @@ export interface RowProps {
   index?: number;
   value: string | JSX.Element;
   selected?: boolean;
+  highlightCheck?: boolean;
   /** The icon on the right side of the label because on the left is the checkmark already. */
   icon?: JSX.Element;
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
@@ -423,6 +424,7 @@ export const Row = ({
   index,
   value,
   selected,
+  highlightCheck = selected,
   onClick,
   icon,
   tooltip,
@@ -436,6 +438,7 @@ export const Row = ({
     id={id}
     role="row"
     aria-selected={selected}
+    data-highlight-check={highlightCheck}
     onClick={onClick}
     tabIndex={-1} // Important for focus handling!
     data-tooltip={tooltip}

--- a/widgets/tag.tsx
+++ b/widgets/tag.tsx
@@ -33,9 +33,7 @@ const Tag = (props: TagProps) => {
       style={style}
       onContextMenu={props.onContextMenu}
     >
-      <span className="label" title={text}>
-        {text}
-      </span>
+      <span className="label">{text}</span>
       {onRemove ? (
         <IconButton
           icon={IconSet.CLOSE}


### PR DESCRIPTION
### New Features / Changes:
- Differentiate between explicitly assigned, inherited, partially assigned, and unassigned tags in the tag selector's suggestions.
  - The checkbox indicator follows this rules:
    - Checked: the tag is assigned (explicitly or inherited), and all selected files have the same assignation of that tag.
    - Highlighted: the tag is explicitly assigned in at least one of the selected files.
- Allow to select the file name text in gallery thumbnails.
- Automatically add the merged tag name and aliases to the selected tag when merging tags.
  - Added a checkbox in the merging dialog to toggle this behavior.
- Add context menu options for files to import tags from metadata, export tags to metadata, and clear tags.
- Clearing the search criteria using the clear button no longer triggers a refetch.
- Thumbnail tags overlay now grows only when hovering the tags, not the whole thumbnail.

### Optimizations:
- Optimized large selections and tag summaries rendering in thumbnails and the file tags editor using incremental rendering.

### Bug fixes:
- Fix bug where the masonry worker did not update correctly after a fetch from an empty view.