### PR TITLE
new features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit"
+    "source.fixAll": "never"
   },
   "prettier.configPath": ".prettierrc.json",
   "search.exclude": {

--- a/common/ExifIO.ts
+++ b/common/ExifIO.ts
@@ -290,6 +290,43 @@ class ExifIO {
     }
   }
 
+  /** Reads metadata from a file and organizes it into a nested object structure */
+  async readData(filepath: string): Promise<{ [key: string]: { [key: string]: any } }> {
+    let metadata: Awaited<ReturnType<typeof ep.readMetadata>> | undefined = undefined;
+    try {
+      metadata = await ep.readMetadata(filepath, ['G0', ...this.extraArgs]);
+      if (metadata.error || !metadata.data?.[0]) {
+        throw new Error(metadata.error || 'No metadata entry');
+      }
+      const entry = metadata.data[0];
+      const nestedData: { [key: string]: { [key: string]: any } } = {};
+      Object.entries(entry).forEach(([key, value]) => {
+        // Separamos el prefijo (categoría) del nombre de la propiedad
+        // Ejemplo: "File:FileName" -> category: "File", prop: "FileName"
+        const [category, ...propParts] = key.split(':');
+        const propName = propParts.join(':');
+
+        if (propName) {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          if (!nestedData[category]) {
+            nestedData[category] = {};
+          }
+          nestedData[category][propName] = value;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          if (!nestedData['General']) {
+            nestedData['General'] = {};
+          }
+          nestedData['General'][category] = value;
+        }
+      });
+      return nestedData;
+    } catch (e) {
+      console.error('Could not read metadata from ', filepath, e, metadata);
+      return { error: { error: 'Could not read metadata' } };
+    }
+  }
+
   /** Adds */
   // async addTag(files: string[], tagHierarchy: string[]) {
   //   // concat file paths into one big string, each surrounded by double quotes

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "extraResources": [
         "resources/exiftool/exiftool.pl",
         "resources/exiftool/lib",
-        "resources/exiftool/.Exiftool_config"
+        "resources/exiftool/.ExifTool_config"
       ]
     },
     "dmg": {
@@ -42,7 +42,7 @@
       "extraResources": [
         "resources/exiftool/exiftool.pl",
         "resources/exiftool/lib",
-        "resources/exiftool/.Exiftool_config"
+        "resources/exiftool/.ExifTool_config"
       ]
     },
     "win": {
@@ -52,7 +52,7 @@
       ],
       "extraResources": [
         "resources/exiftool/exiftool.exe",
-        "resources/exiftool/.Exiftool_config"
+        "resources/exiftool/.ExifTool_config"
       ]
     },
     "extraResources": [

--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -359,6 +359,7 @@
 
 ///////////////////////////
 // Slide mode:
+#overview-inspector-splitter,
 #slide-mode {
   flex-direction: row-reverse;
 

--- a/resources/style/controls/toolbar.scss
+++ b/resources/style/controls/toolbar.scss
@@ -38,3 +38,18 @@
     }
   }
 }
+
+.expandable-button-list {
+  display: flex;
+  flex-wrap: nowrap;
+  width: max-content; 
+  max-width: 32px; 
+  overflow: hidden;
+  transition: max-width 0.9s ease;
+
+  &:hover,
+  :where(:hover) > & {
+    max-width: 500px;
+    aspect-ratio: auto;
+  }
+}

--- a/resources/style/inspector.scss
+++ b/resources/style/inspector.scss
@@ -89,7 +89,57 @@
   }
 }
 
-// File info
+// File info & exif reader
+#exif-viewer {
+  .exif-viewer-toolbar {
+    background-color: var(--shade1);
+    display: flex;
+    width: calc(100% + 0.75rem);
+    padding-inline: 0.75rem;
+    margin-inline: -0.75rem;
+    
+    #exif-viewer-menu,
+    .btn-minimal {
+      background-color: var(--shade1);
+      min-height: unset;
+      border-radius: 0%;
+    }
+
+
+    .btn-minimal {
+      padding-inline: 2rem;
+    }
+
+    &.is-default {
+      button:first-child { 
+        background-color: var(--background-color);
+      }
+    }
+
+    &.is-exif {
+      #exif-viewer-menu {
+        background-color: var(--background-color);
+      }
+    }
+  }
+
+  #exif-viewer-menu {
+    .menu-button-text-elem {
+      padding-inline: 1rem;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+
+      .custom-icon {
+        padding: 3px;
+        margin-left: 3px;
+      }
+    }
+  }
+}
+
+table#exif-info,
 table#file-info {
   display: block;
   border-spacing: 0 0.25rem;

--- a/resources/style/inspector.scss
+++ b/resources/style/inspector.scss
@@ -24,6 +24,26 @@
     */        
   }
 
+  .thumbnail-resize-wrapper {
+    display: flex;
+    flex: 0 0 auto;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden; 
+
+    > * {
+      flex: 1;
+      min-width: 0;
+      min-height: 0;
+      
+      object-fit: contain; 
+      height: 100%;
+      width: 100%;
+    }
+  }
+
   header {
     position: relative;
     text-align: center;

--- a/resources/style/inspector.scss
+++ b/resources/style/inspector.scss
@@ -137,6 +137,33 @@
       }
     }
   }
+
+  #file-editors-panel & {
+    padding: 0.25rem 0.5rem;
+
+    .exif-viewer-toolbar {
+      margin-inline: 0rem;
+      width: 100%;
+      padding-inline: 0;
+
+      &.is-default {
+        button:first-child { 
+          background-color: var(--background-color-alt);
+        }
+      }
+
+      &.is-exif {
+        #exif-viewer-menu {
+          background-color: var(--background-color-alt);
+        }
+      }
+    }
+
+    header {
+      background-color: var(--background-color-alt);
+      outline: none;
+    }
+  }
 }
 
 table#exif-info,
@@ -164,6 +191,7 @@ table#file-info {
   }
 
   td {
+    padding: 2px;
     padding-left: 1rem;
     word-break: break-word;
 

--- a/resources/style/settings.scss
+++ b/resources/style/settings.scss
@@ -112,3 +112,29 @@
     color: var(--text-color-strong);
   }
 }
+
+#page-size-controllers-container {
+  display:  flex;
+  flex-direction: row;
+
+  [role="slider-input"] {
+    flex: 1;
+    width: 50%;
+
+    .input {
+      margin: 3px;
+      width: 5rem;
+      font-family: inherit;
+      text-align: center;
+      transition: all 0.2s ease-in-out;
+
+      &::-webkit-outer-spin-button,
+      &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+      appearance: none;
+      -moz-appearance: textfield;
+    }
+  }
+}

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -34,6 +34,7 @@ import {
   Insertable,
   Expression,
   RawBuilder,
+  Selectable,
 } from 'kysely';
 import { kyselyLogger, migrateToLatest, PAD_STRING_LENGTH } from './config';
 import { DataStorage } from 'src/api/data-storage';
@@ -345,7 +346,7 @@ export default class Backend implements DataStorage {
   }
 
   async fetchFilesByKey(key: keyof FileDTO, values: IndexableType): Promise<FileDTO[]> {
-    console.info('SQLite: Fetching files by key...');
+    console.info('SQLite: Fetching files by key...', key, values);
     if (!['tags', 'extraProperties', 'extraPropertyIDs'].includes(key)) {
       if (!Array.isArray(values)) {
         values = [values as string | number | Date];
@@ -1188,7 +1189,13 @@ function createTimingProxy(obj: Backend): Backend {
   });
 }
 
-function mapToDTO(dbFile: FileDTO | { [x: string]: any }): FileDTO {
+function mapToDTO(
+  dbFile:
+    | (Selectable<Files> & { tags: string[] | null; extraProperties: EpValues[] | null })
+    | {
+        [x: string]: any;
+      },
+): FileDTO {
   // convert data into FileDTO format
   const extraPropertyIDs: ID[] = [];
   const extraProperties: ExtraProperties = {};
@@ -1208,7 +1215,7 @@ function mapToDTO(dbFile: FileDTO | { [x: string]: any }): FileDTO {
     tagSorting: dbFile.tagSorting,
     dateAdded: deserializeDate(dbFile.dateAdded),
     dateModified: deserializeDate(dbFile.dateModified),
-    dateModifiedOS: deserializeDate(dbFile.dateModifiedOS),
+    dateModifiedOS: deserializeDate(dbFile.dateModifiedOs),
     dateLastIndexed: deserializeDate(dbFile.dateLastIndexed),
     dateCreated: deserializeDate(dbFile.dateCreated),
     name: dbFile.name,
@@ -1997,7 +2004,7 @@ function normalizeFiles(sourceFiles: FileDTO[]) {
       height: file.height,
       dateAdded: serializeDate(file.dateAdded),
       dateModified: serializeDate(file.dateModified),
-      dateModifiedOS: serializeDate(file.dateModifiedOS),
+      dateModifiedOs: serializeDate(file.dateModifiedOS),
       dateLastIndexed: serializeDate(file.dateLastIndexed),
       dateCreated: serializeDate(file.dateCreated),
     });

--- a/src/backend/backup-scheduler.ts
+++ b/src/backend/backup-scheduler.ts
@@ -10,27 +10,29 @@ import { getToday, getWeekStart } from 'common/core';
 
 export default class BackupScheduler implements DataBackup {
   #db!: SQLite.Database;
-  #backupDirectory: string = '';
-  #batabaseDirectory: string = '';
+  #backupDirectory: string | undefined = undefined;
+  #databaseDirectory: string | undefined = undefined;
   #lastBackupIndex: number = 0;
   #lastBackupDate: Date = new Date(0);
 
   async init(
     databasePath: string,
-    batabaseDirectory: string,
-    backupDirectory: string,
+    databaseDirectory: string | undefined,
+    backupDirectory: string | undefined,
   ): Promise<string | undefined> {
-    this.#batabaseDirectory = batabaseDirectory;
+    this.#databaseDirectory = databaseDirectory;
     this.#backupDirectory = backupDirectory;
 
-    await fse.ensureDir(backupDirectory);
-    await fse.ensureDir(batabaseDirectory);
-
-    const tempJsonToImport = await BackupScheduler.checkAndRestoreDB(
-      databasePath,
-      batabaseDirectory,
-      backupDirectory,
-    );
+    let tempJsonToImport = undefined;
+    if (databaseDirectory && backupDirectory) {
+      await fse.ensureDir(backupDirectory);
+      await fse.ensureDir(databaseDirectory);
+      tempJsonToImport = await BackupScheduler.checkAndRestoreDB(
+        databasePath,
+        databaseDirectory,
+        backupDirectory,
+      );
+    }
     await fse.ensureFile(databasePath);
 
     this.#db = new SQLite(databasePath, { readonly: true });
@@ -118,6 +120,10 @@ export default class BackupScheduler implements DataBackup {
 
   // Wait 10 seconds after a change for any other changes before creating a backup.
   #createPeriodicBackup = debounce(async (): Promise<void> => {
+    if (!this.#backupDirectory) {
+      console.debug('Skipping #createPeriodicBackup');
+      return;
+    }
     const filePath = path.join(
       this.#backupDirectory,
       `auto-backup-${this.#lastBackupIndex}.sqlite`,
@@ -155,13 +161,17 @@ export default class BackupScheduler implements DataBackup {
   }
 
   async restoreFromFile(sourcePath: string): Promise<void> {
+    if (!this.#databaseDirectory) {
+      console.debug('Skipping #restoreFromFile');
+      return;
+    }
     console.info('SQLite: Importing database backup...', sourcePath);
 
     if (!(await fse.pathExists(sourcePath))) {
       throw new Error(`Backup file not found: ${sourcePath}`);
     }
     const ext = path.extname(sourcePath);
-    const destPath = path.join(this.#batabaseDirectory, `${DB_TO_IMPORT_NAME}${ext}`);
+    const destPath = path.join(this.#databaseDirectory, `${DB_TO_IMPORT_NAME}${ext}`);
     // Replace file to import if exists.
     await fse.remove(destPath);
     await fse.copyFile(sourcePath, destPath);
@@ -169,7 +179,11 @@ export default class BackupScheduler implements DataBackup {
   }
 
   async restoreEmpty(): Promise<void> {
-    const emptyDBPath = path.join(this.#batabaseDirectory, `${DB_TO_IMPORT_NAME}.sqlite`);
+    if (!this.#databaseDirectory) {
+      console.debug('Skipping #restoreEmpty');
+      return;
+    }
+    const emptyDBPath = path.join(this.#databaseDirectory, `${DB_TO_IMPORT_NAME}.sqlite`);
     await fse.remove(emptyDBPath);
     await fse.ensureFile(emptyDBPath);
     const db = new Backend();

--- a/src/backend/migrations/001_migrateJSON.ts
+++ b/src/backend/migrations/001_migrateJSON.ts
@@ -284,7 +284,7 @@ function normalizeFiles(sourceFiles: any[], extraProperties: Insertable<ExtraPro
       height: file.height ?? 10,
       dateAdded: serializeDate(file.dateAdded ? new Date(file.dateAdded) : new Date()),
       dateModified: serializeDate(file.dateModified ? new Date(file.dateModified) : new Date()),
-      dateModifiedOS: serializeDate(
+      dateModifiedOs: serializeDate(
         file.OrigDateModified
           ? new Date(file.OrigDateModified)
           : file.dateModifiedOS

--- a/src/backend/schemaTypes.ts
+++ b/src/backend/schemaTypes.ts
@@ -112,7 +112,7 @@ export type Files = {
   tagSorting: FILE_TAGS_SORTING_TYPE;
   dateAdded: ColumnType<DateAsNumber, DateAsNumber, never>;
   dateModified: DateAsNumber;
-  dateModifiedOS: DateAsNumber;
+  dateModifiedOs: DateAsNumber;
   dateLastIndexed: DateAsNumber;
   name: string;
   extension: IMG_EXTENSIONS_TYPE;

--- a/src/frontend/Preview.tsx
+++ b/src/frontend/Preview.tsx
@@ -63,8 +63,8 @@ const PreviewApp = observer(() => {
 
           <ToolbarButton
             icon={IconSet.INFO}
-            onClick={uiStore.toggleInspector}
-            checked={uiStore.isInspectorOpen}
+            onClick={uiStore.toggleSlideInspector}
+            checked={uiStore.isSlideInspectorOpen}
             text="Toggle the inspector panel"
             tooltip="Toggle the inspector panel"
           />

--- a/src/frontend/components/ExifViewer.tsx
+++ b/src/frontend/components/ExifViewer.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { ClientFile } from '../entities/File';
+import { useStore } from '../contexts/StoreContext';
+import { IconSet } from 'widgets/icons';
+import { MenuButton, MenuItem } from 'widgets/menus';
+import { Button } from 'widgets/button';
+import ImageInfo from './ImageInfo';
+
+interface ExifViewerProps {
+  file: ClientFile;
+}
+
+const defaultGroup = '_info';
+const STORAGE_KEY = 'exif-viewer-selected-group';
+
+const ExifViewer = ({ file }: ExifViewerProps) => {
+  const { exifTool } = useStore();
+  const [exifData, setExifData] = useState<{ [key: string]: { [key: string]: any } }>({});
+  const [selectedGroup, setSelectedgroup] = useState<string>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? saved : defaultGroup;
+  });
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const selectedData = exifData[selectedGroup] ?? { '(No data)': '' };
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, selectedGroup);
+  }, [selectedGroup]);
+
+  useEffect(() => {
+    exifTool
+      .readData(file.absolutePath)
+      .then((data) => {
+        setExifData(data);
+      })
+      .catch((e) => console.error(e));
+  }, [exifTool, file.absolutePath]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const buttonText: React.ReactText = (
+    <div className="menu-button-text-elem">
+      {`Exif ${selectedGroup === defaultGroup ? 'Metadata' : ` (${selectedGroup})`}`}
+      {IconSet.ARROW_DOWN}
+    </div>
+  ) as any;
+
+  return (
+    <div id="exif-viewer">
+      <div
+        className={`exif-viewer-toolbar ${
+          selectedGroup === defaultGroup ? 'is-default' : 'is-exif'
+        }`}
+      >
+        <Button text="Info" onClick={() => setSelectedgroup(defaultGroup)} />
+        <MenuButton
+          icon={<></>}
+          text={buttonText}
+          tooltip="Select exif metadata to view"
+          id="exif-viewer-menu"
+          menuID="__exif-viewer-menu-options"
+        >
+          {Object.keys(exifData)
+            .sort()
+            .map((key) => (
+              <MenuItem key={key} onClick={() => setSelectedgroup(key)} text={key} />
+            ))}
+        </MenuButton>
+      </div>
+      {selectedGroup === defaultGroup ? (
+        <ImageInfo file={file} />
+      ) : (
+        <table id="exif-info">
+          <tbody>
+            {Object.entries(selectedData).map(([field, value]) => (
+              <tr key={field}>
+                <th scope="row">{field}</th>
+                <td>{value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default ExifViewer;

--- a/src/frontend/components/FileExtraPropertiesEditor.tsx
+++ b/src/frontend/components/FileExtraPropertiesEditor.tsx
@@ -38,7 +38,7 @@ interface FileExtraPropertiesEditorProps {
 }
 
 export const FileExtraPropertiesEditor = observer(
-  ({ id, file, addButtonContainerID, menuPlacement }: FileExtraPropertiesEditorProps) => {
+  ({ id, addButtonContainerID, menuPlacement }: FileExtraPropertiesEditorProps) => {
     const { uiStore, fileStore, extraPropertyStore } = useStore();
     const [deletableExtraProperty, setDeletableExtraProperty] = useState<ClientExtraProperty>();
     const [removableExtraProperty, setRemovableExtraProperty] = useState<{
@@ -54,13 +54,13 @@ export const FileExtraPropertiesEditor = observer(
       editableNode: undefined,
     });
 
-    useEffect(() => {
+    /*useEffect(() => {
       runInAction(() => {
         if (file && uiStore.fileSelection.size < 1) {
           uiStore.selectFile(file);
         }
       });
-    }, [file, uiStore]);
+    }, [file, uiStore]);*/
 
     const counter: ExtraPropertiesCounter = useComputed(() => {
       //Map of Clientstores: and a tuple of count, value

--- a/src/frontend/components/FileTagsEditor.tsx
+++ b/src/frontend/components/FileTagsEditor.tsx
@@ -357,11 +357,11 @@ const MatchingTagsList = observer(
     const toggleSelection = useCallback(
       action(async (isSelected: boolean, tag: ClientTag) => {
         if (isSelected) {
-          await uiStore.removeTagsFromSelectedFiles([tag]);
           allSelectedToggleStatus?.set(tag.id, false);
+          await uiStore.removeTagsFromSelectedFiles([tag]);
         } else {
-          await uiStore.addTagsToSelectedFiles([tag]);
           allSelectedToggleStatus?.set(tag.id, true);
+          await uiStore.addTagsToSelectedFiles([tag]);
         }
         resetTextBox();
       }),

--- a/src/frontend/components/FileTagsEditor.tsx
+++ b/src/frontend/components/FileTagsEditor.tsx
@@ -35,6 +35,7 @@ import { Menu, useContextMenu } from 'widgets/menus';
 import { EditorTagSummaryItems } from '../containers/ContentView/menu-items';
 import { useGalleryInputKeydownHandler } from 'src/frontend/hooks/useHandleInputKeydown';
 import { normalizeBase } from 'common/core';
+import useFocusEnforcer from '../hooks/useFocusEnforcer';
 
 const POPUP_ID = 'tag-editor-popup';
 const PANEL_SIZE_ID = 'tag-editor-height';
@@ -203,11 +204,18 @@ export const FileTagsEditor = observer(() => {
     } else {
       inputRef.current?.select();
     }
+    inputRef.current?.focus();
   }, [clearInputOnSelect]);
 
   const removeTag = useAction(async (tag: ClientTag) => {
     await uiStore.removeTagsFromSelectedFiles([tag]);
     inputRef.current?.focus();
+  });
+
+  useFocusEnforcer({
+    ref: panelRef,
+    isActive: !uiStore.areFileEditorsDocked,
+    onFocusLost: resetTextBox,
   });
 
   const handleTagContextMenu = TagSummaryMenu({ parentPopoverId: 'tag-editor' });
@@ -356,6 +364,7 @@ const MatchingTagsList = observer(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const toggleSelection = useCallback(
       action(async (isSelected: boolean, tag: ClientTag) => {
+        resetTextBox();
         if (isSelected) {
           allSelectedToggleStatus?.set(tag.id, false);
           await uiStore.removeTagsFromSelectedFiles([tag]);
@@ -363,7 +372,6 @@ const MatchingTagsList = observer(
           allSelectedToggleStatus?.set(tag.id, true);
           await uiStore.addTagsToSelectedFiles([tag]);
         }
-        resetTextBox();
       }),
       [resetTextBox, allSelectedToggleStatus],
     );

--- a/src/frontend/components/ImageInfo.tsx
+++ b/src/frontend/components/ImageInfo.tsx
@@ -211,7 +211,12 @@ const ImageInfo = ({ file }: ImageInfoProps) => {
                   {!isEditingMode ? (
                     field.format?.(value || '') || value
                   ) : (
-                    <input defaultValue={value || ''} name={key} onKeyDown={stopPropagation} />
+                    <input
+                      className="input"
+                      defaultValue={value || ''}
+                      name={key}
+                      onKeyDown={stopPropagation}
+                    />
                   )}
                 </td>
               </tr>

--- a/src/frontend/containers/AppToolbar/PrimaryCommands.tsx
+++ b/src/frontend/containers/AppToolbar/PrimaryCommands.tsx
@@ -11,6 +11,7 @@ import {
   FileExifEditorButton,
   FileExtraPropertiesEditorButton,
   FileTagEditorButton,
+  InspectorButton,
 } from './ToolbarButtons';
 
 const OutlinerToggle = observer(() => {
@@ -30,7 +31,7 @@ const OutlinerToggle = observer(() => {
 });
 
 const PrimaryCommands = observer(() => {
-  const { fileStore, uiStore } = useStore();
+  const { fileStore } = useStore();
 
   return (
     <>
@@ -50,13 +51,7 @@ const PrimaryCommands = observer(() => {
           <FileTagEditorButton />
           <FileExtraPropertiesEditorButton />
           <FileExifEditorButton />
-          <ToolbarButton
-            icon={IconSet.INFO}
-            onClick={uiStore.toggleOverviewInspector}
-            checked={uiStore.isOverviewInspectorOpen}
-            text="Toggle the inspector panel"
-            tooltip="Toggle the inspector panel"
-          />
+          <InspectorButton />
         </>
         //</div>
       )}
@@ -70,7 +65,7 @@ const PrimaryCommands = observer(() => {
 
 export default PrimaryCommands;
 
-export const SlideModeCommand = observer(() => {
+export const SlideModeCommand = () => {
   const { uiStore } = useStore();
   return (
     <>
@@ -88,16 +83,10 @@ export const SlideModeCommand = observer(() => {
       <FileExtraPropertiesEditorButton />
       <FileExifEditorButton />
 
-      <ToolbarButton
-        icon={IconSet.INFO}
-        onClick={uiStore.toggleInspector}
-        checked={uiStore.isInspectorOpen}
-        text="Toggle the inspector panel"
-        tooltip="Toggle the inspector panel"
-      />
+      <InspectorButton />
     </>
   );
-});
+};
 
 const FileSelectionCommand = observer(() => {
   const { uiStore, fileStore } = useStore();

--- a/src/frontend/containers/AppToolbar/PrimaryCommands.tsx
+++ b/src/frontend/containers/AppToolbar/PrimaryCommands.tsx
@@ -7,7 +7,11 @@ import { FileRemoval } from '../../components/RemovalAlert';
 import { useStore } from '../../contexts/StoreContext';
 import { SortCommand, ViewCommand } from './Menus';
 import Searchbar from './Searchbar';
-import { FileExtraPropertiesEditorButton, FileTagEditorButton } from './ToolbarButtons';
+import {
+  FileExifEditorButton,
+  FileExtraPropertiesEditorButton,
+  FileTagEditorButton,
+} from './ToolbarButtons';
 
 const OutlinerToggle = observer(() => {
   const { uiStore } = useStore();
@@ -44,6 +48,7 @@ const PrimaryCommands = observer(() => {
         <>
           <FileTagEditorButton />
           <FileExtraPropertiesEditorButton />
+          <FileExifEditorButton />
         </>
       )}
 

--- a/src/frontend/containers/AppToolbar/PrimaryCommands.tsx
+++ b/src/frontend/containers/AppToolbar/PrimaryCommands.tsx
@@ -30,7 +30,7 @@ const OutlinerToggle = observer(() => {
 });
 
 const PrimaryCommands = observer(() => {
-  const { fileStore } = useStore();
+  const { fileStore, uiStore } = useStore();
 
   return (
     <>
@@ -45,11 +45,20 @@ const PrimaryCommands = observer(() => {
         <RemoveFilesPopover />
       ) : (
         // Only show when not viewing missing files (so it is replaced by the Delete button)
+        //<div className="expandable-button-list">
         <>
           <FileTagEditorButton />
           <FileExtraPropertiesEditorButton />
           <FileExifEditorButton />
+          <ToolbarButton
+            icon={IconSet.INFO}
+            onClick={uiStore.toggleOverviewInspector}
+            checked={uiStore.isOverviewInspectorOpen}
+            text="Toggle the inspector panel"
+            tooltip="Toggle the inspector panel"
+          />
         </>
+        //</div>
       )}
 
       <SortCommand />
@@ -77,6 +86,7 @@ export const SlideModeCommand = observer(() => {
 
       <FileTagEditorButton />
       <FileExtraPropertiesEditorButton />
+      <FileExifEditorButton />
 
       <ToolbarButton
         icon={IconSet.INFO}

--- a/src/frontend/containers/AppToolbar/ToolbarButtons.tsx
+++ b/src/frontend/containers/AppToolbar/ToolbarButtons.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useStore } from 'src/frontend/contexts/StoreContext';
+import { INTERACTION_PATH_ATTRIBUTE_NAME } from 'src/frontend/hooks/useScopeInteraction';
 import { IconSet } from 'widgets/icons';
 import { ToolbarButton } from 'widgets/toolbar';
 
 export const FileTagEditorButton = () => {
   const { uiStore } = useStore();
   return (
-    <>
+    <div {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}>
       <ToolbarButton
         id="file-tags-editor-button"
         icon={IconSet.TAG_LINE}
@@ -14,21 +15,38 @@ export const FileTagEditorButton = () => {
         text="Tag selected files"
         tooltip="Add or remove tags from selected images"
       />
-    </>
+    </div>
   );
 };
 
 export const FileExtraPropertiesEditorButton = () => {
   const { uiStore } = useStore();
   return (
-    <>
+    <div {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}>
       <ToolbarButton
         id="file-extra-properties-editor-button"
         icon={IconSet.OUTLINER4}
         onClick={uiStore.toggleFileExtraPropertiesEditor}
         text="File extra properties"
         tooltip="Add or remove extra properties from selected images"
+        {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}
       />
-    </>
+    </div>
+  );
+};
+
+export const FileExifEditorButton = () => {
+  const { uiStore } = useStore();
+  return (
+    <div {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}>
+      <ToolbarButton
+        id="file-exif-editor-button"
+        icon={IconSet.INFO}
+        onClick={uiStore.toggleFileExtifEditor}
+        text="File info"
+        tooltip="View or edit the info from the selected image"
+        {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}
+      />
+    </div>
   );
 };

--- a/src/frontend/containers/AppToolbar/ToolbarButtons.tsx
+++ b/src/frontend/containers/AppToolbar/ToolbarButtons.tsx
@@ -1,11 +1,15 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 import { useStore } from 'src/frontend/contexts/StoreContext';
 import { INTERACTION_PATH_ATTRIBUTE_NAME } from 'src/frontend/hooks/useScopeInteraction';
 import { IconSet } from 'widgets/icons';
 import { ToolbarButton } from 'widgets/toolbar';
 
-export const FileTagEditorButton = () => {
+export const FileTagEditorButton = observer(() => {
   const { uiStore } = useStore();
+  if (!uiStore.toolbarButtonsVisibility['fileTags']) {
+    return null;
+  }
   return (
     <div {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}>
       <ToolbarButton
@@ -17,10 +21,13 @@ export const FileTagEditorButton = () => {
       />
     </div>
   );
-};
+});
 
-export const FileExtraPropertiesEditorButton = () => {
+export const FileExtraPropertiesEditorButton = observer(() => {
   const { uiStore } = useStore();
+  if (!uiStore.toolbarButtonsVisibility['extraProperties']) {
+    return null;
+  }
   return (
     <div {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}>
       <ToolbarButton
@@ -33,10 +40,13 @@ export const FileExtraPropertiesEditorButton = () => {
       />
     </div>
   );
-};
+});
 
-export const FileExifEditorButton = () => {
+export const FileExifEditorButton = observer(() => {
   const { uiStore } = useStore();
+  if (!uiStore.toolbarButtonsVisibility['info']) {
+    return null;
+  }
   return (
     <div {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}>
       <ToolbarButton
@@ -49,4 +59,22 @@ export const FileExifEditorButton = () => {
       />
     </div>
   );
-};
+});
+
+export const InspectorButton = observer(() => {
+  const { uiStore } = useStore();
+  const isSlide = uiStore.isSlideMode;
+  const name = isSlide ? 'slideInspector' : 'overviewInspector';
+  if (!uiStore.toolbarButtonsVisibility[name]) {
+    return null;
+  }
+  return (
+    <ToolbarButton
+      icon={IconSet.INFO}
+      onClick={isSlide ? uiStore.toggleSlideInspector : uiStore.toggleOverviewInspector}
+      checked={isSlide ? uiStore.isSlideInspectorOpen : uiStore.isOverviewInspectorOpen}
+      text="Toggle the inspector panel"
+      tooltip="Toggle the inspector panel"
+    />
+  );
+});

--- a/src/frontend/containers/AppToolbar/ToolbarButtons.tsx
+++ b/src/frontend/containers/AppToolbar/ToolbarButtons.tsx
@@ -41,7 +41,7 @@ export const FileExifEditorButton = () => {
     <div {...{ [INTERACTION_PATH_ATTRIBUTE_NAME]: 'floating-panel/file-tags-editor-button' }}>
       <ToolbarButton
         id="file-exif-editor-button"
-        icon={IconSet.INFO}
+        icon={IconSet.META_INFO_2}
         onClick={uiStore.toggleFileExtifEditor}
         text="File info"
         tooltip="View or edit the info from the selected image"

--- a/src/frontend/containers/ContentView/LayoutSwitcher.tsx
+++ b/src/frontend/containers/ContentView/LayoutSwitcher.tsx
@@ -13,6 +13,8 @@ import MasonryRenderer from './Masonry/MasonryRenderer';
 import SlideMode from './SlideMode';
 import { ContentRect } from './utils';
 import { clamp } from 'common/core';
+import { Split } from 'widgets/split';
+import Inspector from '../Inspector';
 
 interface LayoutProps {
   contentRect: ContentRect;
@@ -132,6 +134,10 @@ const Layout = ({ contentRect }: LayoutProps) => {
     return null;
   }
 
+  const { overviewInspectorWidth, isOverviewInspectorOpen } = uiStore;
+  const contentWidth = contentRect.width - (isOverviewInspectorOpen ? overviewInspectorWidth : 0);
+  const contentHeight = contentRect.height;
+
   let overviewElem: React.ReactNode = undefined;
   switch (uiStore.method) {
     case ViewMethod.Grid:
@@ -139,7 +145,7 @@ const Layout = ({ contentRect }: LayoutProps) => {
     case ViewMethod.MasonryHorizontal:
       overviewElem = (
         <MasonryRenderer
-          contentRect={contentRect}
+          contentRect={{ width: contentWidth, height: contentHeight }}
           lastSelectionIndex={lastSelectionIndex}
           select={handleFileSelect}
         />
@@ -148,19 +154,32 @@ const Layout = ({ contentRect }: LayoutProps) => {
     case ViewMethod.List:
       overviewElem = (
         <ListGallery
-          contentRect={contentRect}
+          contentRect={{ width: contentWidth, height: contentHeight }}
           select={handleFileSelect}
           lastSelectionIndex={lastSelectionIndex}
         />
       );
       break;
     default:
-      overviewElem = 'unknown view method';
+      overviewElem = <>{'unknown view method'}</>;
   }
+
+  const overviewElemWithInspector = (
+    <Split
+      id="overview-inspector-splitter"
+      primary={<Inspector />}
+      secondary={overviewElem}
+      axis="vertical"
+      align="right"
+      splitPoint={overviewInspectorWidth}
+      isExpanded={isOverviewInspectorOpen}
+      onMove={uiStore.moveOverviewInspectorSplitter}
+    />
+  );
 
   return (
     <>
-      {overviewElem}
+      {overviewElemWithInspector}
       {delayedSlideMode && uiStore.firstFileInView && <SlideMode contentRect={contentRect} />}
     </>
   );

--- a/src/frontend/containers/ContentView/SlideMode/index.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/index.tsx
@@ -18,8 +18,8 @@ import { Vec2, createDimension, createTransform } from './utils';
 
 const SlideMode = observer(({ contentRect }: { contentRect: ContentRect }) => {
   const { uiStore } = useStore();
-  const isInspectorOpen = uiStore.isInspectorOpen;
-  const inspectorWidth = uiStore.inspectorWidth;
+  const isInspectorOpen = uiStore.isSlideInspectorOpen;
+  const inspectorWidth = uiStore.slideInspectorWidth;
   const contentWidth = contentRect.width - (isInspectorOpen ? inspectorWidth : 0);
   const contentHeight = contentRect.height;
 
@@ -33,7 +33,7 @@ const SlideMode = observer(({ contentRect }: { contentRect: ContentRect }) => {
       align="right"
       splitPoint={inspectorWidth}
       isExpanded={isInspectorOpen}
-      onMove={uiStore.moveInspectorSplitter}
+      onMove={uiStore.moveSlideInspectorSplitter}
     />
   );
 });

--- a/src/frontend/containers/Inspector/index.tsx
+++ b/src/frontend/containers/Inspector/index.tsx
@@ -3,11 +3,11 @@ import { observer } from 'mobx-react-lite';
 
 import { useStore } from '../../contexts/StoreContext';
 import FileTags from '../../components/FileTag';
-import ImageInfo from '../../components/ImageInfo';
 import { IconButton, IconSet } from 'widgets';
 import { shell } from 'electron';
 import { IS_PREVIEW_WINDOW } from 'common/window';
 import FileExtraPropertiesEditor from '../../components/FileExtraPropertiesEditor';
+import ExifViewer from 'src/frontend/components/ExifViewer';
 
 const Inspector = observer(() => {
   const { uiStore, fileStore } = useStore();
@@ -25,7 +25,7 @@ const Inspector = observer(() => {
 
   return (
     <aside id="inspector" className="multi-scroll">
-      <section>{first && <ImageInfo file={first} />}</section>
+      <section>{first && <ExifViewer file={first} />}</section>
       <section>
         <header>
           <h2>Path to file</h2>

--- a/src/frontend/containers/Inspector/index.tsx
+++ b/src/frontend/containers/Inspector/index.tsx
@@ -13,7 +13,11 @@ import { Thumbnail } from '../ContentView/GalleryItem';
 const Inspector = observer(() => {
   const { uiStore, fileStore } = useStore();
 
-  if (uiStore.firstItemIndex >= fileStore.fileList.length || !uiStore.isInspectorOpen) {
+  if (
+    uiStore.firstItemIndex >= fileStore.fileList.length ||
+    (uiStore.isSlideMode && !uiStore.isSlideInspectorOpen) ||
+    (!uiStore.isSlideMode && !uiStore.isOverviewInspectorOpen)
+  ) {
     return (
       <aside id="inspector">
         <Placeholder />
@@ -80,7 +84,7 @@ export default Inspector;
 
 const Placeholder = () => {
   return (
-    <section>
+    <section style={{ overflow: 'hidden' }}>
       <header>
         <h2>No image selected</h2>
       </header>

--- a/src/frontend/containers/Inspector/index.tsx
+++ b/src/frontend/containers/Inspector/index.tsx
@@ -8,6 +8,7 @@ import { shell } from 'electron';
 import { IS_PREVIEW_WINDOW } from 'common/window';
 import FileExtraPropertiesEditor from '../../components/FileExtraPropertiesEditor';
 import ExifViewer from 'src/frontend/components/ExifViewer';
+import { Thumbnail } from '../ContentView/GalleryItem';
 
 const Inspector = observer(() => {
   const { uiStore, fileStore } = useStore();
@@ -20,11 +21,21 @@ const Inspector = observer(() => {
     );
   }
 
-  const first = fileStore.fileList[uiStore.firstItemIndex];
+  const first = uiStore.firstSelectedFile ?? uiStore.firstFileInView;
   const path = first ? first.absolutePath : '...';
 
   return (
     <aside id="inspector" className="multi-scroll">
+      {!uiStore.isSlideMode && first && (
+        <section className="thumbnail-resize-wrapper">
+          <Thumbnail
+            file={first}
+            mounted={true}
+            forceNoThumbnail={true}
+            galleryVideoPlaybackMode="auto"
+          />
+        </section>
+      )}
       <section>{first && <ExifViewer file={first} />}</section>
       <section>
         <header>

--- a/src/frontend/containers/Outliner/FileEditorsPanel/index.tsx
+++ b/src/frontend/containers/Outliner/FileEditorsPanel/index.tsx
@@ -62,7 +62,7 @@ const FileEditorsPanel = observer(({ className }: Partial<MultiSplitPaneProps>) 
         title: 'File Info',
         content:
           uiStore.firstFileInView !== undefined ? (
-            <ExifViewer file={uiStore.firstFileInView} />
+            <ExifViewer file={uiStore.firstSelectedFile ?? uiStore.firstFileInView} />
           ) : (
             <></>
           ),

--- a/src/frontend/containers/Outliner/FileEditorsPanel/index.tsx
+++ b/src/frontend/containers/Outliner/FileEditorsPanel/index.tsx
@@ -5,13 +5,14 @@ import { FileExtraPropertiesEditor } from 'src/frontend/components/FileExtraProp
 import { FileTagsEditor } from 'src/frontend/components/FileTagsEditor';
 import { observer } from 'mobx-react-lite';
 import { MultiSplitPaneProps } from 'widgets/MultiSplit/MultiSplitPane';
+import ExifViewer from 'src/frontend/components/ExifViewer';
 
 const defaultPanel = {
   type: 'none',
   title: '---',
   isOpen: false,
   onBlur: () => {},
-  ignoreOnBlur: (e: React.FocusEvent) => {
+  ignoreOnBlur: (e: MouseEvent | FocusEvent) => {
     void e;
     return false;
   },
@@ -29,8 +30,9 @@ const FileEditorsPanel = observer(({ className }: Partial<MultiSplitPaneProps>) 
         title: 'File Tags Editor',
         content: <FileTagsEditor />,
         onBlur: uiStore.closeFileTagsEditor,
-        ignoreOnBlur: (e: React.FocusEvent) => {
-          return e.relatedTarget?.id === 'file-tags-editor-button';
+        ignoreOnBlur: (e: MouseEvent | FocusEvent) => {
+          void e;
+          return false;
         },
       };
     }
@@ -47,8 +49,27 @@ const FileEditorsPanel = observer(({ className }: Partial<MultiSplitPaneProps>) 
           />
         ),
         onBlur: uiStore.closeFileExtraPropertiesEditor,
-        ignoreOnBlur: (e: React.FocusEvent) => {
-          return e.relatedTarget?.id === 'file-extra-properties-editor-button';
+        ignoreOnBlur: (e) => {
+          void e;
+          return false;
+        },
+      };
+    }
+    if (uiStore.isFileExifEditorOpen) {
+      return {
+        type: 'exif',
+        isOpen: true,
+        title: 'File Info',
+        content:
+          uiStore.firstFileInView !== undefined ? (
+            <ExifViewer file={uiStore.firstFileInView} />
+          ) : (
+            <></>
+          ),
+        onBlur: uiStore.closeFileExtifEditor,
+        ignoreOnBlur: (e) => {
+          void e;
+          return false;
         },
       };
     }

--- a/src/frontend/containers/Settings/Appearance.tsx
+++ b/src/frontend/containers/Settings/Appearance.tsx
@@ -84,6 +84,51 @@ export const Appearance = observer(() => {
         </RadioGroup>
       </div>
 
+      <h3>Toolbar Buttons</h3>
+
+      <div className="vstack">
+        <Toggle
+          checked={uiStore.toolbarButtonsVisibility['fileTags']}
+          onChange={() => {
+            uiStore.toggleToolbarButtonVisibility('fileTags');
+          }}
+        >
+          Show File Tags Editor Button
+        </Toggle>
+        <Toggle
+          checked={uiStore.toolbarButtonsVisibility['extraProperties']}
+          onChange={() => {
+            uiStore.toggleToolbarButtonVisibility('extraProperties');
+          }}
+        >
+          Show File Extra Properties Editor Button
+        </Toggle>
+        <Toggle
+          checked={uiStore.toolbarButtonsVisibility['info']}
+          onChange={() => {
+            uiStore.toggleToolbarButtonVisibility('info');
+          }}
+        >
+          Show File Info Viewer Button
+        </Toggle>
+        <Toggle
+          checked={uiStore.toolbarButtonsVisibility['overviewInspector']}
+          onChange={() => {
+            uiStore.toggleToolbarButtonVisibility('overviewInspector');
+          }}
+        >
+          Show Inspector Button in Overview Mode
+        </Toggle>
+        <Toggle
+          checked={uiStore.toolbarButtonsVisibility['slideInspector']}
+          onChange={() => {
+            uiStore.toggleToolbarButtonVisibility('slideInspector');
+          }}
+        >
+          Show Inspector Button in Slide Mode
+        </Toggle>
+      </div>
+
       <h3>Thumbnail</h3>
 
       <div className="vstack">

--- a/src/frontend/containers/Settings/UsagePreferences.tsx
+++ b/src/frontend/containers/Settings/UsagePreferences.tsx
@@ -3,9 +3,44 @@ import React from 'react';
 import { useStore } from '../../contexts/StoreContext';
 import UiStore from 'src/frontend/stores/UiStore';
 import { Toggle } from 'widgets/checkbox';
+import { Slider } from 'widgets/slider';
+
+// moved the labes one item up to aling them visually in the ui
+const pageSizeOptions = [
+  { value: 0, label: '250' },
+  { value: 250 },
+  { value: 500, label: '1K' },
+  { value: 1000 },
+  { value: 1500, label: '2K' },
+  { value: 2000 },
+  { value: 2500, label: '3K' },
+  { value: 3000 },
+  { value: 3500, label: '4K' },
+  { value: 4000 },
+  { value: 4500, label: '5K' },
+  { value: 5000 },
+  { value: 5500, label: '6K' },
+  { value: 6000 },
+  { value: 6500, label: '7K' },
+  { value: 7000 },
+  { value: 7500, label: '8K' },
+  { value: 8000 },
+  { value: 8500, label: '9K' },
+  { value: 9000 },
+  { value: 9500, label: '10K' },
+  { value: 10000 },
+];
 
 export const UsagePreferences = observer(() => {
-  const { uiStore } = useStore();
+  const { uiStore, fileStore } = useStore();
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = parseInt(e.target.value, 10);
+    if (isNaN(val)) {
+      return;
+    }
+    fileStore.setPaginationSize(val);
+  };
+
   return (
     <>
       <h3>Tag Selectors</h3>
@@ -17,6 +52,39 @@ export const UsagePreferences = observer(() => {
           Clear Tag Search Text After Select
         </Toggle>
         <RecentTagsNumber />
+      </div>
+
+      <h3>Gallery</h3>
+      <div className="vstack">
+        <div id="page-size-controllers-container">
+          <Slider
+            value={fileStore.paginationSize}
+            label={
+              <span>
+                <b>Pagination Size:</b> Number of files initially loaded and when reaching the
+                scroll edge.{' '}
+                <span style={{ fontWeight: 'lighter' }}>
+                  (This setting heavily impacts memory usage and performance)
+                </span>
+              </span>
+            }
+            onChange={fileStore.setPaginationSize}
+            id="pagination-size-slider"
+            options={pageSizeOptions}
+            min={pageSizeOptions[0].value}
+            max={pageSizeOptions[pageSizeOptions.length - 1].value}
+            step={20}
+            secondaryInput={
+              <input
+                type="number"
+                className="input"
+                value={fileStore.paginationSize}
+                onChange={handleInputChange}
+                step={20}
+              />
+            }
+          />
+        </div>
       </div>
     </>
   );

--- a/src/frontend/entities/Location.ts
+++ b/src/frontend/entities/Location.ts
@@ -507,6 +507,17 @@ export class ClientLocation {
       } else if (data.type === 'error') {
         const { value } = data;
         console.error('Location watch error:', value);
+        if (value === 'ENOENT') {
+          AppToaster.show(
+            {
+              message: `An error has occurred while reading a new file at location "${this.name}".`,
+              timeout: 3000,
+              type: 'warning',
+            },
+            'location-error',
+          );
+          return;
+        }
         AppToaster.show(
           {
             message: `An error has occured while ${

--- a/src/frontend/entities/Tag.ts
+++ b/src/frontend/entities/Tag.ts
@@ -264,6 +264,10 @@ export class ClientTag {
     return Array.from(this.getAncestors(), (t) => `${t.isHeader ? '#' : ''}${t.name}`).reverse();
   }
 
+  get cleanPath(): string[] {
+    return Array.from(this.getAncestors(), (t) => t.name).reverse();
+  }
+
   @computed get pathCharLength(): number {
     let total = 0;
     for (let i = 0; i < this.path.length; i++) {

--- a/src/frontend/hooks/useFocusEnforcer.ts
+++ b/src/frontend/hooks/useFocusEnforcer.ts
@@ -1,0 +1,61 @@
+import { useEffect, useCallback, RefObject } from 'react';
+
+interface FocusOptions {
+  isActive: boolean;
+  ref: RefObject<HTMLElement | null>; // Pasamos la ref del panel
+  onFocusLost: () => void;
+  whitelistSelector?: string;
+}
+
+const DATA_ATTR = 'data-focus-enforcer-zone';
+
+const useFocusEnforcer = ({
+  isActive,
+  ref,
+  onFocusLost,
+  whitelistSelector = '[data-contextmenu="true"]',
+}: FocusOptions) => {
+  const checkAndRestore = useCallback(() => {
+    // request animation frame to allow the DOM to update focus
+    requestAnimationFrame(() => {
+      const activeEl = document.activeElement;
+      if (!activeEl || activeEl === document.body) {
+        onFocusLost();
+        return;
+      }
+      const isInMyPanel = ref.current?.contains(activeEl);
+      const isInOtherPanel = activeEl.closest(`[${DATA_ATTR}]`);
+      const isInWhitelist = whitelistSelector && activeEl.closest(whitelistSelector);
+
+      // If not in any claimed element reclaim focus
+      if (!isInMyPanel && !isInOtherPanel && !isInWhitelist) {
+        ref.current?.focus();
+        onFocusLost();
+      }
+    });
+  }, [onFocusLost, whitelistSelector, ref]);
+
+  useEffect(() => {
+    if (!isActive || !ref.current) {
+      return;
+    }
+
+    // Add claimed attr to know if any elemnt is claimed by another instance of the hook
+    // This prevents the hook from fighting with other components for focus.
+    const element = ref.current;
+    element.setAttribute(DATA_ATTR, 'true');
+
+    // Add global listeners
+    document.addEventListener('click', checkAndRestore, true);
+    document.addEventListener('keydown', checkAndRestore, true);
+
+    return () => {
+      // remove listener on unmount
+      element.removeAttribute(DATA_ATTR);
+      document.removeEventListener('click', checkAndRestore, true);
+      document.removeEventListener('keydown', checkAndRestore, true);
+    };
+  }, [isActive, ref, checkAndRestore]);
+};
+
+export default useFocusEnforcer;

--- a/src/frontend/hooks/useScopeInteraction.ts
+++ b/src/frontend/hooks/useScopeInteraction.ts
@@ -1,0 +1,70 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+export interface ScopeInteractionProps {
+  /** Hierarchical path (e.g., "main-menu/option-1") */
+  currentPath: string;
+  /** Triggered when an interaction occurs outside the currentPath branch */
+  onOutside?: (event: MouseEvent | FocusEvent) => void;
+  /** Triggered when an interaction occurs within the currentPath branch */
+  onInside?: (event: MouseEvent | FocusEvent) => void;
+  /** Optional Ref to automatically assign the data-logical-path attribute */
+  elementRef?: RefObject<Element | null>;
+}
+
+export const INTERACTION_PATH_ATTRIBUTE_NAME = 'data-logical-path';
+
+/**
+ * Hook to detect interactions (click or focus) outside of a conceptual/hierarchical element tree.
+ *
+ * It allows managing interaction behaviors like "blur" or others for elements that are logically related (parent/child)
+ * but might be physically separated in the DOM (e.g., Portals, Floating UI).
+ *
+ * It uses a prefix-based path matching (e.g., "menu" matches "menu/sub-menu/item-1").
+ *
+ * @param currentPath - Hierarchical path (e.g., "main-menu/option-1").
+ * @param outsideCallback - Triggered when an interaction occurs outside the currentPath branch.
+ * @param insideCallback - Triggered when an interaction occurs within the currentPath branch.
+ * @param elementRef - Optional Ref to automatically assign the data-logical-path attribute.
+ */
+export function useScopeInteraction({
+  currentPath,
+  onOutside,
+  onInside,
+  elementRef,
+}: ScopeInteractionProps) {
+  // Save the callback in refs to avoid unnesseesary redefine listener if the dev uses anonymous callbacks
+  const handlers = useRef({ onOutside, onInside });
+
+  useEffect(() => {
+    handlers.current = { onOutside, onInside };
+  }, [onOutside, onInside]);
+
+  useEffect(() => {
+    if (elementRef?.current) {
+      elementRef.current.setAttribute(INTERACTION_PATH_ATTRIBUTE_NAME, currentPath);
+    }
+
+    const handleInteraction = (event: MouseEvent | FocusEvent) => {
+      // get the new focused or target element
+      const target = event.target as Element;
+      // search for any ancestor that is children of the current path
+      const interactiveEl = target.closest(`[${INTERACTION_PATH_ATTRIBUTE_NAME}]`);
+      const targetPath = interactiveEl?.getAttribute(INTERACTION_PATH_ATTRIBUTE_NAME) || '';
+
+      // if no match, or the path is not a children of the current path take it as a focus outside
+      if (!targetPath.startsWith(currentPath)) {
+        handlers.current.onOutside?.(event);
+      } else {
+        handlers.current.onInside?.(event);
+      }
+    };
+
+    document.addEventListener('mousedown', handleInteraction);
+    document.addEventListener('focusin', handleInteraction);
+
+    return () => {
+      document.removeEventListener('mousedown', handleInteraction);
+      document.removeEventListener('focusin', handleInteraction);
+    };
+  }, [currentPath, elementRef]);
+}

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -1117,13 +1117,13 @@ class FileStore {
         this.index.set(file.id, index);
       }
     }
-    this.fileList.replace(newFiles);
     this.fileDimensions.replace(
-      this.fileList.map((f) => ({
+      newFiles.map((f) => ({
         width: f ? f.width : 100,
         height: f ? f.height : 100,
       })),
     );
+    this.fileList.replace(newFiles);
     this.numLoadedFiles = this.definedFiles.length;
   }
 
@@ -1394,7 +1394,7 @@ class FileStore {
 
     // For every new file coming in, either re-use the existing client file if it exists,
     // or construct a new client file
-    const { status, newFiles } = await this.filesFromBackend(backendFiles, isReplace);
+    const { status, newFiles } = await this.filesFromBackend(backendFiles, false);
     if (status != Status.success) {
       return;
     }

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -1341,9 +1341,17 @@ class FileStore {
     }
   }
 
+  private isCountingInBackground = false;
   private async _fetchMissingFiles(count: true): Promise<number>;
   private async _fetchMissingFiles(count?: false): Promise<ClientFile[]>;
   @action private async _fetchMissingFiles(count: boolean = false): Promise<number | ClientFile[]> {
+    // prevent multiple background countings to be executed at the same time
+    if (count) {
+      if (this.isCountingInBackground) {
+        throw new Error('Already counting missing files in background');
+      }
+      this.isCountingInBackground = true;
+    }
     // Fetch all files, then check their existence and only show the missing ones
     // Similar to {@link updateFromBackend}, but the existence check needs to be awaited before we can show the images
     // process all the backend files in batches
@@ -1358,10 +1366,30 @@ class FileStore {
     // or ignore cancelations by new fetch tasks
     const isViewContent = this.showsMissingContent;
     // Indicate a new fetch process if needed
-    const start = await this.newFetchTaskId();
+    let start = 0;
+    if (!count) {
+      start = await this.newFetchTaskId();
+    }
 
     let cancelled = false;
     const isCancelled = () => cancelled;
+
+    const showProgressToaster = () => {
+      const percentage = Math.min(((batchNum * batchSize) / total) * 100, 100).toFixed(1);
+      AppToaster.show(
+        {
+          message: `Scanning for missing files ${percentage}%...`,
+          timeout: 1200,
+          clickAction: {
+            label: 'Cancel',
+            onClick: () => {
+              cancelled = true;
+            },
+          },
+        },
+        'scanning-missing',
+      );
+    };
 
     const allMissingClientFiles = await batchReducer(
       makeFileBatchFetcher(this.backend, batchSize),
@@ -1391,7 +1419,7 @@ class FileStore {
           return definedFiles.map((clientFile, i) => async () => {
             const exists = await fse.pathExists(clientFile.absolutePath);
             clientFile.setBroken(!exists);
-            if (exists) {
+            if (count || exists) {
               clientFile.dispose();
             }
             if (isViewContent && ((batchStart + i) % step === 0 || i === total - 1)) {
@@ -1420,6 +1448,7 @@ class FileStore {
         );
 
         batchNum++;
+        showProgressToaster();
         return count
           ? (acc as number) + missingClientFiles.length
           : (acc as ClientFile[]).concat(missingClientFiles);
@@ -1431,11 +1460,17 @@ class FileStore {
     if (isCancelled()) {
       if (!count) {
         (allMissingClientFiles as ClientFile[]).forEach((f) => f.dispose);
+      } else {
+        this.isCountingInBackground = false;
       }
       throw new Error('FETCH MISSING ABORTED');
     }
-    const end = performance.now();
-    this.setAverageFetchTime(end - start);
+    if (!count) {
+      const end = performance.now();
+      this.setAverageFetchTime(end - start);
+    } else {
+      this.isCountingInBackground = false;
+    }
 
     return allMissingClientFiles;
   }
@@ -1539,7 +1574,9 @@ class FileStore {
   }> {
     // get current task Id and update the sub Id
     const taskId: [number, number] = [this.fetchTaskIdPair[0], performance.now()];
-    this.fetchTaskIdPair[1] = taskId[1];
+    if (!ignoreCancel) {
+      this.fetchTaskIdPair[1] = taskId[1];
+    }
     const total = backendFiles.length;
 
     // Copy of the current fileList and index to process reused and dispose unused ClienFiles
@@ -1747,8 +1784,12 @@ class FileStore {
       }
       this.dirtyUntaggedFiles = false;
       if (withMissing) {
-        const missingCount = await this._fetchMissingFiles(true);
-        runInAction(() => {
+        const currentMissing = runInAction(() => this.numMissingFiles);
+        const missingCount = await this._fetchMissingFiles(true).catch((e) => {
+          console.error(e);
+          return currentMissing;
+        });
+        runInAction(async () => {
           this.numMissingFiles = missingCount;
           this.dirtyMissingFiles = false;
         });

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -135,7 +135,7 @@ class FileStore {
     this.rootStore = rootStore;
     makeObservable(this);
 
-    this.debouncedRefetch = debounce(this.refetch, 800).bind(this);
+    this.debouncedRefetch = debounce(this.refetch, 1600).bind(this);
     this.debouncedSaveFilesToSave = debounce(this.saveFilesToSave, 200).bind(this);
     // reaction to keep updated properties "related" to fileList
   }
@@ -146,33 +146,67 @@ class FileStore {
 
   @action.bound async readTagsFromFiles(_?: React.MouseEvent, onlySelected = false): Promise<void> {
     const toastKey = 'read-tags-from-file';
-    try {
-      const files = onlySelected
-        ? Array.from(this.rootStore.uiStore.fileSelection)
-        : this.fileList.slice();
+    const isAllFilesSelected = this.rootStore.uiStore.isAllFilesSelected;
+    const selectedFiles = Array.from(this.rootStore.uiStore.fileSelection);
+    const batchSize = 200;
+    const numFiles =
+      isAllFilesSelected || !onlySelected ? this.numFilteredFiles : selectedFiles.length;
+    let count = 0;
+    let isCancelled = false;
+    const cancelled = () => isCancelled;
+    const failedClickAction = { label: 'Open DevTools', onClick: RendererMessenger.toggleDevTools };
+
+    const showProgressToaster = () => {
+      const percentage = ((count / numFiles) * 100).toFixed(2);
+      AppToaster.show(
+        {
+          message: `Reading tags from ${numFiles} files ${percentage}%...`,
+          timeout: 0,
+          clickAction: {
+            label: 'Cancel',
+            onClick: () => {
+              isCancelled = true;
+            },
+          },
+        },
+        toastKey,
+      );
+    };
+    const showFinishToast = (_t: any, _c: any, status: Status) => {
+      const isError = status === Status.error;
+      const message = isError
+        ? 'Reading tags from files failed. Check the dev console for more details'
+        : 'Reading tags from files... Done!';
+      AppToaster.show(
+        {
+          message: message,
+          timeout: 5000,
+        },
+        toastKey,
+      );
+      AppToaster.show(
+        {
+          message: message,
+          timeout: 5000,
+          clickAction: isError ? failedClickAction : undefined,
+        },
+        toastKey,
+      );
+    };
+    const processBatch = async (files: ClientFile[]) => {
       const numFiles = files.length;
       for (let i = 0; i < numFiles; i++) {
-        AppToaster.show(
-          {
-            message: `Reading tags from files ${((100 * i) / numFiles).toFixed(0)}%...`,
-            timeout: 0,
-          },
-          toastKey,
-        );
-        const file = files[i];
-        if (!file) {
-          continue;
+        if (cancelled()) {
+          break;
         }
-
+        showProgressToaster();
+        const file = files[i];
         const absolutePath = file.absolutePath;
-
         try {
           const tagsNameHierarchies = await this.rootStore.exifTool.readTags(absolutePath);
-
           // Now that we know the tag names in file metadata, add them to the files in Allusion
           // Main idea: Find matching tag with same name, otherwise, insert new
           //   for now, just match by the name at the bottom of the hierarchy
-
           const { tagStore } = this.rootStore;
           for (const tagHierarchy of tagsNameHierarchies) {
             const match = tagStore.findByNameOrAlias(tagHierarchy[tagHierarchy.length - 1]);
@@ -220,23 +254,26 @@ class FileStore {
         } catch (e) {
           console.error('Could not import extraProperties for', absolutePath, e);
         }
+        count++;
       }
-      AppToaster.show(
-        {
-          message: 'Reading tags from files... Done!',
-          timeout: 5000,
-        },
-        toastKey,
+    };
+
+    if (isAllFilesSelected || !onlySelected) {
+      await this.dispatchToFilteredFiles(
+        processBatch,
+        () => {},
+        cancelled,
+        showFinishToast,
+        batchSize,
       );
-    } catch (e) {
-      console.error('Could not read tags', e);
-      AppToaster.show(
-        {
-          message: 'Reading tags from files failed. Check the dev console for more details',
-          timeout: 5000,
-        },
-        toastKey,
-      );
+      this.rootStore.fileStore.refetch();
+    } else {
+      let status = Status.success;
+      await processBatch(selectedFiles).catch((e) => {
+        console.error('Could not read tags', e);
+        status = Status.error;
+      });
+      showFinishToast(undefined, undefined, status);
     }
   }
 
@@ -246,11 +283,49 @@ class FileStore {
 
   @action.bound async writeTagsToFiles(_?: React.MouseEvent, onlySelected = false): Promise<void> {
     const toastKey = 'write-tags-to-file';
-    try {
-      const files = onlySelected
-        ? Array.from(this.rootStore.uiStore.fileSelection)
-        : this.definedFiles.slice();
-      const numFiles = files.length;
+    const isAllFilesSelected = this.rootStore.uiStore.isAllFilesSelected;
+    const selectedFiles = Array.from(this.rootStore.uiStore.fileSelection);
+    const batchSize = 200;
+    const numFiles =
+      isAllFilesSelected || !onlySelected ? this.numFilteredFiles : selectedFiles.length;
+    let count = 0;
+    let isCancelled = false;
+    const cancelled = () => isCancelled;
+    const failedClickAction = { label: 'Open DevTools', onClick: RendererMessenger.toggleDevTools };
+
+    const showProgressToaster = () => {
+      if (!isCancelled) {
+        const percentage = ((count / numFiles) * 100).toFixed(2);
+        AppToaster.show(
+          {
+            message: `Writing tags to ${numFiles} files ${percentage}%...`,
+            timeout: 0,
+            clickAction: {
+              label: 'Cancel',
+              onClick: () => {
+                isCancelled = true;
+              },
+            },
+          },
+          toastKey,
+        );
+      }
+    };
+    const showFinishToast = (_t: any, _c: any, status: Status) => {
+      const isError = status === Status.error;
+      const message = isError
+        ? 'Writing tags to files failed. Check the dev console for more details'
+        : 'Writing tags to files... Done!';
+      AppToaster.show(
+        {
+          message: message,
+          timeout: 5000,
+          clickAction: isError ? failedClickAction : undefined,
+        },
+        toastKey,
+      );
+    };
+    const processBatch = async (files: ClientFile[]) => {
       const fileTagsProps = runInAction(() =>
         files.map((f) => {
           const extraProps: Record<string, ExtraPropertyValue> = {};
@@ -261,49 +336,42 @@ class FileStore {
             absolutePath: f.absolutePath,
             tagHierarchy: Array.from(
               f.tags,
-              action((t) => t.path),
+              action((t) => t.cleanPath),
             ),
             extraPropsValues: JSON.stringify(extraProps),
           };
         }),
       );
-      let lastToastVal = '0';
       for (let i = 0; i < fileTagsProps.length; i++) {
-        const newToastVal = ((100 * i) / numFiles).toFixed(0);
-        if (lastToastVal !== newToastVal) {
-          lastToastVal = newToastVal;
-          AppToaster.show(
-            {
-              message: `Writing tags to files ${newToastVal}%...`,
-              timeout: 0,
-            },
-            toastKey,
-          );
+        if (cancelled()) {
+          break;
         }
-
+        showProgressToaster();
         const { absolutePath, tagHierarchy, extraPropsValues } = fileTagsProps[i];
         try {
           await this.rootStore.exifTool.writeTags(absolutePath, tagHierarchy, extraPropsValues);
         } catch (e) {
           console.error('Could not write tags to', absolutePath, tagHierarchy, e);
         }
+        count++;
       }
-      AppToaster.show(
-        {
-          message: 'Writing tags to files... Done!',
-          timeout: 5000,
-        },
-        toastKey,
+    };
+
+    if (isAllFilesSelected || !onlySelected) {
+      await this.dispatchToFilteredFiles(
+        processBatch,
+        () => {},
+        cancelled,
+        showFinishToast,
+        batchSize,
       );
-    } catch (e) {
-      console.error('Could not write tags', e);
-      AppToaster.show(
-        {
-          message: 'Writing tags to files failed. Check the dev console for more details',
-          timeout: 5000,
-        },
-        toastKey,
-      );
+    } else {
+      let status = Status.success;
+      await processBatch(selectedFiles).catch((e) => {
+        console.error(e);
+        status = Status.error;
+      });
+      showFinishToast(undefined, undefined, status);
     }
   }
 

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -61,7 +61,8 @@ type PersistentPreferenceFields =
   | 'numUntaggedFiles'
   | 'dirtyUntaggedFiles'
   | 'numMissingFiles'
-  | 'dirtyMissingFiles';
+  | 'dirtyMissingFiles'
+  | 'paginationSize';
 
 export const enum Content {
   All,
@@ -77,9 +78,9 @@ const ContentLabels: Record<Content, string> = {
   [Content.Query]: 'Query',
 };
 
-const PAGE_SIZE = 256;
-
 class FileStore {
+  static MIN_PAGINATION_SIZE = 250;
+
   private readonly backend: DataStorage;
   private readonly rootStore: RootStore;
 
@@ -108,6 +109,7 @@ class FileStore {
   @observable orderBy: OrderBy<FileDTO> = 'dateAdded';
   @observable isNaturalOrderingEnabled: boolean = false;
   @observable orderByExtraProperty: ID = '';
+  @observable paginationSize: number = FileStore.MIN_PAGINATION_SIZE;
 
   @observable numTotalFiles = 0;
   @observable dirtyTotalFiles = true;
@@ -755,6 +757,9 @@ class FileStore {
     );
   }
 
+  @action.bound setPaginationSize(val: number): void {
+    this.paginationSize = Math.max(val || 0, FileStore.MIN_PAGINATION_SIZE);
+  }
   @action.bound setNumLoadedFiles(val: number): void {
     this.numLoadedFiles = val;
   }
@@ -995,7 +1000,7 @@ class FileStore {
       this.orderBy,
       this.orderDirection,
       this.isNaturalOrderingEnabled,
-      PAGE_SIZE, // 256, // limit
+      this.paginationSize, // 250, // limit
       direction ?? 'after', // pagination
       cursor, // cursor
       this.orderByExtraProperty,
@@ -1009,7 +1014,7 @@ class FileStore {
     // which caused visual jumps.
 
     // Fetch the top half first.
-    args[3] = Math.trunc(PAGE_SIZE / 2); // split page size
+    args[3] = Math.trunc(this.paginationSize / 2); // split page size
     args[4] = 'before';
     const topHalf = await this.backend.searchFiles(criterias, ...args);
     // bottom half
@@ -1288,6 +1293,9 @@ class FileStore {
         if (prefs.orderByExtraProperty) {
           this.setOrderByExtraProperty(prefs.orderByExtraProperty);
         }
+        if (prefs.paginationSize) {
+          this.setPaginationSize(prefs.paginationSize);
+        }
         if (prefs.averageFetchTimes) {
           this.averageFetchTimes.replace(new Map(prefs.averageFetchTimes));
         }
@@ -1316,6 +1324,7 @@ class FileStore {
       orderDirection: this.orderDirection,
       isNaturalOrderingEnabled: this.isNaturalOrderingEnabled,
       orderByExtraProperty: this.orderByExtraProperty,
+      paginationSize: this.paginationSize,
       averageFetchTimes: Array.from(this.averageFetchTimes.entries()),
       numTotalFiles: this.numTotalFiles,
       dirtyTotalFiles: this.dirtyTotalFiles,

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -1015,8 +1015,10 @@ class FileStore {
     // bottom half
     args[4] = 'after';
     const bottomitem = topHalf.at(-1);
-    // if no items returned by bottom half use the same cursor
+    // if no items returned by top half set the cursor as undefined
     args[5] = bottomitem ? this.toCursor(bottomitem) : undefined;
+    // Set the first item again to avoid losing the position if the refetch was by deleting files.
+    this.rootStore.uiStore.setFirstItem(bottomitem);
     const bottomHalf = await this.backend.searchFiles(criterias, ...args);
     return topHalf.concat(bottomHalf);
   }

--- a/src/frontend/stores/LocationStore.ts
+++ b/src/frontend/stores/LocationStore.ts
@@ -666,17 +666,22 @@ class LocationStore {
     }
   }
 
-  @action hideFile(path: string): void {
+  @action async hideFile(path: string): Promise<void> {
     // This is called when an image is removed from the filesystem.
     // Could also mean that a file was renamed or moved, in which case addFile was called already:
     // its path will have changed, so we won't find it here, which is fine, it'll be detected as missing later.
     const fileStore = this.rootStore.fileStore;
     const clientFile = fileStore.fileList.find((f) => f && f.absolutePath === path);
 
-    fileStore.setDirtyMissingFiles(true);
     if (clientFile) {
       fileStore.hideFile(clientFile);
       fileStore.debouncedRefetch();
+    } else {
+      // If the hidden file exists in the DB but not in the current fileList, mark missingFilesCount as dirty.
+      const dbMatch = (await this.backend.fetchFilesByKey('absolutePath', path))[0];
+      if (dbMatch) {
+        fileStore.setDirtyMissingFiles(true);
+      }
     }
   }
 

--- a/src/frontend/stores/LocationStore.ts
+++ b/src/frontend/stores/LocationStore.ts
@@ -20,6 +20,7 @@ import { ClientTag } from '../entities/Tag';
 import { IS_MAC, IS_WIN } from 'common/process';
 import { BackendType } from '@parcel/watcher';
 import { execSync } from 'child_process';
+import { debounce } from 'common/timeout';
 
 const PREFERENCES_STORAGE_KEY = 'location-store-preferences';
 type Preferences = { extensions: IMG_EXTENSIONS_TYPE[] };
@@ -58,12 +59,16 @@ class LocationStore {
   // Allow users to disable certain file types. Global option for now, needs restart
   // TODO: Maybe per location/sub-location?
   readonly enabledFileExtensions = observable(new Set<IMG_EXTENSIONS_TYPE>());
+  private filesToUpdate: Map<string, FileStats> = new Map();
+  debouncedUpdateFilesToUpdate: () => Promise<void>;
 
   constructor(backend: DataStorage, rootStore: RootStore) {
     this.backend = backend;
     this.rootStore = rootStore;
 
     makeObservable(this);
+
+    this.debouncedUpdateFilesToUpdate = debounce(this.updateFilestoUpdate, 1200).bind(this);
   }
 
   @action async init(): Promise<void> {
@@ -650,17 +655,24 @@ class LocationStore {
     fileStore.debouncedRefetch();
   }
 
-  @action async updateFile(fileStats: FileStats): Promise<void> {
+  updateFile(file: FileStats): void {
+    this.filesToUpdate.set(file.absolutePath, file);
+    // Debouncing the file update action improves performance when bulk writing file metadata.
+    this.debouncedUpdateFilesToUpdate();
+  }
+
+  @action async updateFilestoUpdate(): Promise<void> {
+    const fileStats = Array.from(this.filesToUpdate.values());
+    this.filesToUpdate.clear();
     const fileStore = this.rootStore.fileStore;
     const dbMatchOverwrites = await this.backend.fetchFilesByKey(
       'absolutePath',
-      fileStats.absolutePath,
+      fileStats.map((fs) => fs.absolutePath),
     );
-    const dbMatchOverwrite = dbMatchOverwrites.length > 0 ? dbMatchOverwrites[0] : undefined;
-    if (dbMatchOverwrite) {
+    if (dbMatchOverwrites.length > 0) {
       await this.updateChangedFiles(
-        [dbMatchOverwrite],
-        new Map<string, FileStats>([[fileStats.absolutePath, fileStats]]),
+        dbMatchOverwrites,
+        new Map<string, FileStats>(fileStats.map((fs) => [fs.absolutePath, fs])),
       );
       fileStore.debouncedRefetch();
     }

--- a/src/frontend/stores/LocationStore.ts
+++ b/src/frontend/stores/LocationStore.ts
@@ -674,7 +674,10 @@ class LocationStore {
         dbMatchOverwrites,
         new Map<string, FileStats>(fileStats.map((fs) => [fs.absolutePath, fs])),
       );
-      fileStore.debouncedRefetch();
+      // Do a refetch except if inside slide mode to avoid to exit it.
+      if (runInAction(() => !this.rootStore.uiStore.isSlideMode)) {
+        fileStore.debouncedRefetch();
+      }
     }
   }
 

--- a/src/frontend/stores/RootStore.ts
+++ b/src/frontend/stores/RootStore.ts
@@ -99,11 +99,7 @@ class RootStore {
     const fileStoreInit =
       numCriterias === 0
         ? rootStore.fileStore.fetchAllFiles
-        : async () => {
-            // When searching by criteria, the file counts and startup Loads won't be set (only when fetching all files),
-            // so fetch them manually
-            await rootStore.fileStore.fetchFilesByQuery();
-          };
+        : rootStore.fileStore.fetchFilesByQuery;
 
     // Load the files already in the database so user instantly sees their images
     fileStoreInit();

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -948,18 +948,20 @@ class UiStore {
 
   /** Adds tags to selection. If all files are selected, it updates the filtered set in backend.*/
   @action.bound async addTagsToSelectedFiles(tags: ClientTag[]): Promise<void> {
+    const selection = Array.from(this.rootStore.uiStore.fileSelection);
+    selection.forEach((f) => f.addTags(tags));
     if (this.isAllFilesSelected) {
       await this.rootStore.fileStore.addTagsToFilteredFiles(tags);
     }
-    this.fileSelection.forEach((f) => f.addTags(tags));
   }
 
   /** Removes tags from selection. If all files are selected, it updates the filtered set in backend.*/
   @action.bound async removeTagsFromSelectedFiles(tags: ClientTag[]): Promise<void> {
+    const selection = Array.from(this.rootStore.uiStore.fileSelection);
+    selection.forEach((f) => tags.forEach((t) => f.removeTag(t)));
     if (this.isAllFilesSelected) {
       await this.rootStore.fileStore.removeTagsFromFilteredFiles(tags);
     }
-    this.fileSelection.forEach((f) => tags.forEach((t) => f.removeTag(t)));
   }
 
   @action.bound selectFile(file?: ClientFile, clear?: boolean): void {

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -138,6 +138,7 @@ type PersistentPreferenceFields =
   | 'areFileEditorsDocked'
   | 'isFileTagsEditorOpen'
   | 'isFileExtraPropertiesEditorOpen'
+  | 'isFileExifEditorOpen'
   | 'thumbnailDirectory'
   | 'taggingServiceURL'
   | 'taggingServiceParallelRequests'
@@ -223,9 +224,10 @@ class UiStore {
   @observable isRefreshing: boolean = false;
 
   @observable areFileEditorsDocked: boolean = false;
-  @observable isFileTagsEditorOpen: boolean = false;
   @observable focusTagEditor: boolean = false;
+  @observable isFileTagsEditorOpen: boolean = false;
   @observable isFileExtraPropertiesEditorOpen: boolean = false;
+  @observable isFileExifEditorOpen: boolean = false;
   /** Dialog for removing unlinked files from Allusion's database */
   @observable isToolbarFileRemoverOpen: boolean = false;
   /** Dialog for moving files to the system's trash bin, and removing from Allusion's database */
@@ -284,6 +286,7 @@ class UiStore {
       (isOpen) => {
         if (isOpen) {
           this.isFileExtraPropertiesEditorOpen = false;
+          this.isFileExifEditorOpen = false;
         }
       },
     );
@@ -293,6 +296,17 @@ class UiStore {
       (isOpen) => {
         if (isOpen) {
           this.isFileTagsEditorOpen = false;
+          this.isFileExifEditorOpen = false;
+        }
+      },
+    );
+
+    reaction(
+      () => this.isFileExifEditorOpen,
+      (isOpen) => {
+        if (isOpen) {
+          this.isFileTagsEditorOpen = false;
+          this.isFileExtraPropertiesEditorOpen = false;
         }
       },
     );
@@ -734,6 +748,10 @@ class UiStore {
     this.areFileEditorsDocked = val;
   }
 
+  @action.bound setFocusTagEditor(value: boolean): void {
+    this.focusTagEditor = value;
+  }
+
   @action.bound toggleFileTagsEditor(): void {
     this.isFileTagsEditorOpen = !this.isFileTagsEditorOpen;
     this.focusTagEditor = true;
@@ -748,10 +766,6 @@ class UiStore {
     this.isFileTagsEditorOpen = false;
   }
 
-  @action.bound setFocusTagEditor(value: boolean): void {
-    this.focusTagEditor = value;
-  }
-
   @action.bound toggleFileExtraPropertiesEditor(): void {
     this.isFileExtraPropertiesEditorOpen = !this.isFileExtraPropertiesEditorOpen;
   }
@@ -764,6 +778,20 @@ class UiStore {
 
   @action.bound closeFileExtraPropertiesEditor(): void {
     this.isFileExtraPropertiesEditorOpen = false;
+  }
+
+  @action.bound toggleFileExtifEditor(): void {
+    this.isFileExifEditorOpen = !this.isFileExifEditorOpen;
+  }
+
+  @action.bound openFileExtifEditor(): void {
+    if (this.fileSelection.size > 0) {
+      this.isFileExifEditorOpen = true;
+    }
+  }
+
+  @action.bound closeFileExtifEditor(): void {
+    this.isFileExifEditorOpen = false;
   }
 
   @action.bound openLocationRecovery(locationId: ID): void {
@@ -1525,6 +1553,7 @@ class UiStore {
         this.isFileTagsEditorOpen = Boolean(prefs.isFileTagsEditorOpen ?? false);
         this.isClearTagSelectorsOnSelectEnabled = Boolean(prefs.isClearTagSelectorsOnSelectEnabled ?? false); // eslint-disable-line prettier/prettier
         this.isFileExtraPropertiesEditorOpen = Boolean(prefs.isFileExtraPropertiesEditorOpen ?? false); // eslint-disable-line prettier/prettier
+        this.isFileExifEditorOpen = Boolean(prefs.isFileExifEditorOpen ?? false); // eslint-disable-line prettier/prettier
         this.outlinerWidth = Math.max(Number(prefs.outlinerWidth), UiStore.MIN_OUTLINER_WIDTH);
         this.inspectorWidth = Math.max(Number(prefs.inspectorWidth), UiStore.MIN_INSPECTOR_WIDTH);
         Object.entries<string>(prefs.hotkeyMap).forEach(
@@ -1588,6 +1617,7 @@ class UiStore {
       areFileEditorsDocked: this.areFileEditorsDocked,
       isFileTagsEditorOpen: this.isFileTagsEditorOpen,
       isFileExtraPropertiesEditorOpen: this.isFileExtraPropertiesEditorOpen,
+      isFileExifEditorOpen: this.isFileExifEditorOpen,
       thumbnailDirectory: this.thumbnailDirectory,
       taggingServiceURL: this.taggingServiceURL,
       taggingServiceParallelRequests: this.taggingServiceParallelRequests,

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -52,6 +52,15 @@ export type Theme = (typeof Themes)[number];
 const ScrollbarsStyles = ['classic', 'hover'] as const;
 export type ScrollbarsStyle = (typeof ScrollbarsStyles)[number];
 
+const ToolbarButtonNames = [
+  'fileTags',
+  'extraProperties',
+  'info',
+  'overviewInspector',
+  'slideInspector',
+] as const;
+export type ToolbarButtonName = (typeof ToolbarButtonNames)[number];
+
 export interface IHotkeyMap {
   // Outliner actions
   toggleOutliner: string;
@@ -78,6 +87,7 @@ export interface IHotkeyMap {
   openFileTagsEditor: string;
   toggleExtraPropertiesEditor: string;
   toggleEditTagProperties: string;
+  toggleLeftFileInfoViewer: string;
 
   // Other
   openPreviewWindow: string;
@@ -89,8 +99,9 @@ export const defaultHotkeyMap: IHotkeyMap = {
   toggleOutliner: '1',
   toggleInspector: '2',
   openFileTagsEditor: '3',
-  toggleExtraPropertiesEditor: '4',
-  toggleEditTagProperties: '5',
+  toggleEditTagProperties: '4',
+  toggleExtraPropertiesEditor: '5',
+  toggleLeftFileInfoViewer: '6',
   replaceQuery: 'q',
   toggleSettings: 's',
   toggleHelpCenter: 'h',
@@ -134,7 +145,7 @@ type PersistentPreferenceFields =
   | 'theme'
   | 'scrollbarsStyle'
   | 'isOutlinerOpen'
-  | 'isInspectorOpen'
+  | 'isSlideInspectorOpen'
   | 'isOverviewInspectorOpen'
   | 'areFileEditorsDocked'
   | 'isFileTagsEditorOpen'
@@ -161,7 +172,7 @@ type PersistentPreferenceFields =
   | 'outlinerWidth'
   | 'outlinerExpansion'
   | 'outlinerHeights'
-  | 'inspectorWidth'
+  | 'slideInspectorWidth'
   | 'overviewInspectorWidth'
   | 'recentlyUsedTagsMaxLength'
   | 'recentlyUsedTags'
@@ -189,7 +200,7 @@ class UiStore {
   // UI
   @observable zoomFactor: number = 1;
   @observable isOutlinerOpen: boolean = true;
-  @observable isInspectorOpen: boolean = true;
+  @observable isSlideInspectorOpen: boolean = true;
   @observable isOverviewInspectorOpen: boolean = false;
   @observable isSettingsOpen: boolean = false;
   @observable isHelpCenterOpen: boolean = false;
@@ -203,7 +214,7 @@ class UiStore {
   @observable outlinerWidth: number = UiStore.MIN_OUTLINER_WIDTH;
   readonly outlinerExpansion = observable<boolean>([true, true, true, true]);
   readonly outlinerHeights = observable<number>([200, 200, 200, 200]);
-  @observable inspectorWidth: number = UiStore.MIN_INSPECTOR_WIDTH;
+  @observable slideInspectorWidth: number = UiStore.MIN_INSPECTOR_WIDTH;
   @observable overviewInspectorWidth: number = UiStore.MIN_INSPECTOR_WIDTH;
   /** Whether to show the tags on images in the content view */
   @observable thumbnailTagOverlayMode: ThumbnailTagOverlayModeType = 'all';
@@ -227,6 +238,10 @@ class UiStore {
   @observable showTreeConnectorLines: boolean = false;
   @observable isRefreshing: boolean = false;
 
+  /** Indicates the visibility of each toolbar button */
+  @observable toolbarButtonsVisibility: Record<ToolbarButtonName, boolean> = Object.fromEntries(
+    ToolbarButtonNames.map((name) => [name, true]),
+  ) as Record<ToolbarButtonName, boolean>;
   @observable areFileEditorsDocked: boolean = false;
   @observable focusTagEditor: boolean = false;
   @observable isFileTagsEditorOpen: boolean = false;
@@ -651,12 +666,12 @@ class UiStore {
     absolutePaths.forEach((path) => shell.openPath(`file://${path}`).catch(console.error));
   }
 
-  @action.bound toggleInspector(): void {
-    this.isInspectorOpen = !this.isInspectorOpen;
+  @action.bound toggleSlideInspector(): void {
+    this.isSlideInspectorOpen = !this.isSlideInspectorOpen;
   }
 
-  @action.bound openInspector(): void {
-    this.isInspectorOpen = true;
+  @action.bound openSlideInspector(): void {
+    this.isSlideInspectorOpen = true;
   }
 
   @action.bound toggleOverviewInspector(): void {
@@ -750,6 +765,14 @@ class UiStore {
 
   @action.bound closeManyExternalFiles(): void {
     this.isManyExternalFilesOpen = false;
+  }
+
+  @action.bound setToolbarButtonVisibility(name: ToolbarButtonName, value: boolean): void {
+    this.toolbarButtonsVisibility[name] = value;
+  }
+
+  @action.bound toggleToolbarButtonVisibility(name: ToolbarButtonName): void {
+    this.toolbarButtonsVisibility[name] = !this.toolbarButtonsVisibility[name];
   }
 
   @action.bound toggleFileEditorsDocked(): void {
@@ -1405,11 +1428,17 @@ class UiStore {
     if (matches(hotkeyMap.toggleOutliner)) {
       this.toggleOutliner();
     } else if (matches(hotkeyMap.toggleInspector)) {
-      this.toggleInspector();
+      if (this.isSlideMode) {
+        this.toggleSlideInspector();
+      } else {
+        this.toggleOverviewInspector();
+      }
     } else if (matches(hotkeyMap.openFileTagsEditor)) {
       this.openFileTagsEditor();
     } else if (matches(hotkeyMap.toggleExtraPropertiesEditor)) {
       this.toggleFileExtraPropertiesEditor();
+    } else if (matches(hotkeyMap.toggleLeftFileInfoViewer)) {
+      this.toggleFileExtifEditor();
     } else if (matches(hotkeyMap.toggleEditTagProperties)) {
       this.toggleEditTagProperties();
     } else if (matches(hotkeyMap.refreshSearch)) {
@@ -1472,18 +1501,18 @@ class UiStore {
     this.outlinerHeights.replace(newVal);
   }
 
-  @action.bound moveInspectorSplitter(x: number, width: number): void {
+  @action.bound moveSlideInspectorSplitter(x: number, width: number): void {
     // The inspector is on the right side, so we need to calculate the offset.
     const offsetX = width - x;
-    if (this.isInspectorOpen) {
+    if (this.isSlideInspectorOpen) {
       const w = clamp(offsetX, UiStore.MIN_INSPECTOR_WIDTH, width * 0.75);
-      this.inspectorWidth = w;
+      this.slideInspectorWidth = w;
 
       if (offsetX < UiStore.MIN_INSPECTOR_WIDTH * 0.75) {
-        this.isInspectorOpen = false;
+        this.isSlideInspectorOpen = false;
       }
     } else if (offsetX >= UiStore.MIN_INSPECTOR_WIDTH) {
-      this.isInspectorOpen = true;
+      this.isSlideInspectorOpen = true;
     }
   }
 
@@ -1518,7 +1547,7 @@ class UiStore {
           this.setScrollbarsStyle(prefs.scrollbarsStyle);
         }
         this.setIsOutlinerOpen(prefs.isOutlinerOpen);
-        this.isInspectorOpen = Boolean(prefs.isInspectorOpen);
+        this.isSlideInspectorOpen = Boolean(prefs.isSlideInspectorOpen);
         this.isOverviewInspectorOpen = Boolean(prefs.isOverviewInspectorOpen);
         if (prefs.thumbnailDirectory) {
           this.setThumbnailDirectory(prefs.thumbnailDirectory);
@@ -1583,11 +1612,8 @@ class UiStore {
         this.isFileExtraPropertiesEditorOpen = Boolean(prefs.isFileExtraPropertiesEditorOpen ?? false); // eslint-disable-line prettier/prettier
         this.isFileExifEditorOpen = Boolean(prefs.isFileExifEditorOpen ?? false); // eslint-disable-line prettier/prettier
         this.outlinerWidth = Math.max(Number(prefs.outlinerWidth), UiStore.MIN_OUTLINER_WIDTH);
-        this.inspectorWidth = Math.max(Number(prefs.inspectorWidth), UiStore.MIN_INSPECTOR_WIDTH);
-        this.overviewInspectorWidth = Math.max(
-          Number(prefs.overviewInspectorWidth),
-          UiStore.MIN_INSPECTOR_WIDTH,
-        );
+        this.slideInspectorWidth = Math.max(Number(prefs.slideInspectorWidth), UiStore.MIN_INSPECTOR_WIDTH); // eslint-disable-line prettier/prettier
+        this.overviewInspectorWidth = Math.max(Number(prefs.overviewInspectorWidth), UiStore.MIN_INSPECTOR_WIDTH); // eslint-disable-line prettier/prettier
         Object.entries<string>(prefs.hotkeyMap).forEach(
           ([k, v]) => k in defaultHotkeyMap && (this.hotkeyMap[k as keyof IHotkeyMap] = v),
         );
@@ -1645,7 +1671,7 @@ class UiStore {
       theme: this.theme,
       scrollbarsStyle: this.scrollbarsStyle,
       isOutlinerOpen: this.isOutlinerOpen,
-      isInspectorOpen: this.isInspectorOpen,
+      isSlideInspectorOpen: this.isSlideInspectorOpen,
       isOverviewInspectorOpen: this.isOverviewInspectorOpen,
       areFileEditorsDocked: this.areFileEditorsDocked,
       isFileTagsEditorOpen: this.isFileTagsEditorOpen,
@@ -1672,7 +1698,7 @@ class UiStore {
       outlinerExpansion: this.outlinerExpansion.slice(),
       outlinerHeights: this.outlinerHeights.slice(),
       outlinerWidth: this.outlinerWidth,
-      inspectorWidth: this.inspectorWidth,
+      slideInspectorWidth: this.slideInspectorWidth,
       overviewInspectorWidth: this.overviewInspectorWidth,
       isRefreshLocationsStartupEnabled: this.isRefreshLocationsStartupEnabled,
       isRememberSearchEnabled: this.isRememberSearchEnabled,
@@ -1717,6 +1743,7 @@ class UiStore {
 
   /** Return {@link UiStore.firstItemIndex}: first item visible in viewport, and the current item in SlideMode */
   @computed get firstFileInView(): ClientFile | undefined {
+    this.rootStore.fileStore.fileListLastRefetch; // touch for reactivity
     return this.firstItem ? this.rootStore.fileStore.get(this.firstItem.id) : undefined;
   }
 

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -135,6 +135,7 @@ type PersistentPreferenceFields =
   | 'scrollbarsStyle'
   | 'isOutlinerOpen'
   | 'isInspectorOpen'
+  | 'isOverviewInspectorOpen'
   | 'areFileEditorsDocked'
   | 'isFileTagsEditorOpen'
   | 'isFileExtraPropertiesEditorOpen'
@@ -161,6 +162,7 @@ type PersistentPreferenceFields =
   | 'outlinerExpansion'
   | 'outlinerHeights'
   | 'inspectorWidth'
+  | 'overviewInspectorWidth'
   | 'recentlyUsedTagsMaxLength'
   | 'recentlyUsedTags'
   | 'isClearTagSelectorsOnSelectEnabled'
@@ -188,6 +190,7 @@ class UiStore {
   @observable zoomFactor: number = 1;
   @observable isOutlinerOpen: boolean = true;
   @observable isInspectorOpen: boolean = true;
+  @observable isOverviewInspectorOpen: boolean = false;
   @observable isSettingsOpen: boolean = false;
   @observable isHelpCenterOpen: boolean = false;
   @observable isAboutOpen: boolean = false;
@@ -201,6 +204,7 @@ class UiStore {
   readonly outlinerExpansion = observable<boolean>([true, true, true, true]);
   readonly outlinerHeights = observable<number>([200, 200, 200, 200]);
   @observable inspectorWidth: number = UiStore.MIN_INSPECTOR_WIDTH;
+  @observable overviewInspectorWidth: number = UiStore.MIN_INSPECTOR_WIDTH;
   /** Whether to show the tags on images in the content view */
   @observable thumbnailTagOverlayMode: ThumbnailTagOverlayModeType = 'all';
   @observable inheritedTagsVisibilityMode: InheritedTagsVisibilityModeType =
@@ -653,6 +657,14 @@ class UiStore {
 
   @action.bound openInspector(): void {
     this.isInspectorOpen = true;
+  }
+
+  @action.bound toggleOverviewInspector(): void {
+    this.isOverviewInspectorOpen = !this.isOverviewInspectorOpen;
+  }
+
+  @action.bound openOverviewInspector(): void {
+    this.isOverviewInspectorOpen = true;
   }
 
   @action.bound toggleSettings(): void {
@@ -1475,6 +1487,21 @@ class UiStore {
     }
   }
 
+  @action.bound moveOverviewInspectorSplitter(x: number, width: number): void {
+    // The inspector is on the right side, so we need to calculate the offset.
+    const offsetX = width - x;
+    if (this.isOverviewInspectorOpen) {
+      const w = clamp(offsetX, UiStore.MIN_INSPECTOR_WIDTH, width * 0.75);
+      this.overviewInspectorWidth = w;
+
+      if (offsetX < UiStore.MIN_INSPECTOR_WIDTH * 0.75) {
+        this.isOverviewInspectorOpen = false;
+      }
+    } else if (offsetX >= UiStore.MIN_INSPECTOR_WIDTH) {
+      this.isOverviewInspectorOpen = true;
+    }
+  }
+
   // Storing preferences
   @action recoverPersistentPreferences(): void {
     const prefsString = localStorage.getItem(PREFERENCES_STORAGE_KEY);
@@ -1492,6 +1519,7 @@ class UiStore {
         }
         this.setIsOutlinerOpen(prefs.isOutlinerOpen);
         this.isInspectorOpen = Boolean(prefs.isInspectorOpen);
+        this.isOverviewInspectorOpen = Boolean(prefs.isOverviewInspectorOpen);
         if (prefs.thumbnailDirectory) {
           this.setThumbnailDirectory(prefs.thumbnailDirectory);
         }
@@ -1556,6 +1584,10 @@ class UiStore {
         this.isFileExifEditorOpen = Boolean(prefs.isFileExifEditorOpen ?? false); // eslint-disable-line prettier/prettier
         this.outlinerWidth = Math.max(Number(prefs.outlinerWidth), UiStore.MIN_OUTLINER_WIDTH);
         this.inspectorWidth = Math.max(Number(prefs.inspectorWidth), UiStore.MIN_INSPECTOR_WIDTH);
+        this.overviewInspectorWidth = Math.max(
+          Number(prefs.overviewInspectorWidth),
+          UiStore.MIN_INSPECTOR_WIDTH,
+        );
         Object.entries<string>(prefs.hotkeyMap).forEach(
           ([k, v]) => k in defaultHotkeyMap && (this.hotkeyMap[k as keyof IHotkeyMap] = v),
         );
@@ -1614,6 +1646,7 @@ class UiStore {
       scrollbarsStyle: this.scrollbarsStyle,
       isOutlinerOpen: this.isOutlinerOpen,
       isInspectorOpen: this.isInspectorOpen,
+      isOverviewInspectorOpen: this.isOverviewInspectorOpen,
       areFileEditorsDocked: this.areFileEditorsDocked,
       isFileTagsEditorOpen: this.isFileTagsEditorOpen,
       isFileExtraPropertiesEditorOpen: this.isFileExtraPropertiesEditorOpen,
@@ -1640,6 +1673,7 @@ class UiStore {
       outlinerHeights: this.outlinerHeights.slice(),
       outlinerWidth: this.outlinerWidth,
       inspectorWidth: this.inspectorWidth,
+      overviewInspectorWidth: this.overviewInspectorWidth,
       isRefreshLocationsStartupEnabled: this.isRefreshLocationsStartupEnabled,
       isRememberSearchEnabled: this.isRememberSearchEnabled,
       isSlideMode: this.isSlideMode,

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -19,6 +19,7 @@ import { AppToaster } from '../components/Toaster';
 import { ClientSearchGroup, isClientSearchGroup } from '../entities/SearchItem';
 import { SearchGroupDTO } from 'src/api/file-search';
 import { Cursor, SearchConjunction } from 'src/api/data-storage-search';
+import { FileDTO } from 'src/api/file';
 
 export const enum ViewMethod {
   List,
@@ -453,10 +454,10 @@ class UiStore {
   }
 
   @action.bound setFirstItem(
-    item: number | ClientFile | undefined = 0,
+    item: number | ClientFile | FileDTO | undefined = 0,
     validate: boolean = true,
   ): void {
-    if (item instanceof ClientFile) {
+    if (item && (item instanceof ClientFile || typeof item === 'object')) {
       this.firstItem = this.rootStore.fileStore.toCursor(item);
       return;
     }

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -77,6 +77,7 @@ export interface IHotkeyMap {
   deselectAll: string;
   viewList: string;
   viewGrid: string;
+  newRandomOrder: string;
   viewMasonryVertical: string;
   viewMasonryHorizontal: string;
   viewSlide: string;
@@ -111,6 +112,7 @@ export const defaultHotkeyMap: IHotkeyMap = {
   viewSlide: 'enter', // TODO: backspace and escape are hardcoded hotkeys to exist slide mode
   viewList: 'alt + 1',
   viewGrid: 'alt + 2',
+  newRandomOrder: 'shift + r',
   viewMasonryVertical: 'alt + 3',
   viewMasonryHorizontal: 'alt + 4',
   search: 'mod + f',
@@ -479,6 +481,10 @@ class UiStore {
 
   @action.bound setMethodGrid(): void {
     this.method = ViewMethod.Grid;
+  }
+
+  @action.bound newRandomOrder(): void {
+    this.rootStore.fileStore.orderFilesBy('random');
   }
 
   @action.bound setMethodMasonryVertical(): void {
@@ -1464,6 +1470,8 @@ class UiStore {
       this.setMethodList();
     } else if (matches(hotkeyMap.viewGrid)) {
       this.setMethodGrid();
+    } else if (matches(hotkeyMap.newRandomOrder)) {
+      this.newRandomOrder();
     } else if (matches(hotkeyMap.viewMasonryVertical)) {
       this.setMethodMasonryVertical();
     } else if (matches(hotkeyMap.viewMasonryHorizontal)) {

--- a/src/frontend/workers/folderWatcher.worker.ts
+++ b/src/frontend/workers/folderWatcher.worker.ts
@@ -57,7 +57,7 @@ export class FolderWatcherWorker {
     // watch for this https://github.com/parcel-bundler/watcher/pull/207
 
     const handleEvents = // Small indentation hack to avoid affecting git blame
-      (events: parcelWatcher.Event[], extensions: IMG_EXTENSIONS_TYPE[]) => {
+      async (events: parcelWatcher.Event[], extensions: IMG_EXTENSIONS_TYPE[]) => {
         for (const event of events) {
           // Ignore Files that aren't our extension type
           const ext = SysPath.extname(event.path).toLowerCase().split('.')[1];
@@ -132,7 +132,9 @@ export class FolderWatcherWorker {
           console.error('Error fired in watcher', directory, err);
           ctx.postMessage({ type: 'error', value: err });
         }
-        handleEvents(events, extensions);
+        handleEvents(events, extensions).catch(err => {
+            ctx.postMessage({ type: 'error', value: err.code });
+        });
       },
       { ignore: [], backend: backend },
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -651,6 +651,10 @@ MainMessenger.onSendPreviewFiles((msg) => {
     MainMessenger.onceInitialized().then(() => {
       if (previewWindow) {
         MainMessenger.sendPreviewFiles(previewWindow.webContents, msg);
+        if (!previewWindow.isVisible()) {
+          previewWindow.show();
+        }
+        previewWindow.focus();
       }
     });
   } else {

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -211,7 +211,6 @@ async function runMainApp(dbPath: string, dbDirectory: string, root: Root): Prom
 }
 
 async function runPreviewApp(dbPath: string, root: Root): Promise<void> {
-  return;
   //const backend = await Backend.init(dbPath, () => {});
   // TODO: create an apropiated initPreview mode
   const backend = new Backend();
@@ -222,7 +221,7 @@ async function runPreviewApp(dbPath: string, root: Root): Promise<void> {
     async () => {},
   );
   const backupScheduler = new BackupScheduler();
-  await backupScheduler.init(dbPath, '', '');
+  await backupScheduler.init(dbPath, undefined, undefined);
   const rootStore = await RootStore.preview(backend, backupScheduler);
 
   RendererMessenger.initialized();

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -236,7 +236,7 @@ async function runPreviewApp(dbPath: string, root: Root): Promise<void> {
         rootStore.uiStore.enableSlideMode();
 
         runInAction(() => {
-          rootStore.uiStore.isInspectorOpen = false;
+          rootStore.uiStore.isSlideInspectorOpen = false;
         });
 
         const files = await backend.fetchFilesByID(ids);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": "./",
     "paths": {
       "widgets/*": ["widgets/*"],

--- a/widgets/FloatingPanel.tsx
+++ b/widgets/FloatingPanel.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useCallback, useEffect, useRef } from 'react';
 import FocusManager from 'src/frontend/FocusManager';
 import { IconSet } from 'widgets/icons';
 import { Toolbar } from './toolbar';
+import { ScopeInteractionProps, useScopeInteraction } from 'src/frontend/hooks/useScopeInteraction';
 
 interface IFloatingPanelProps {
   id: string;
@@ -9,7 +10,7 @@ interface IFloatingPanelProps {
   title?: string;
   className?: string;
   onBlur: () => void;
-  ignoreOnBlur?: (e: React.FocusEvent) => boolean;
+  ignoreOnBlur?: (e: MouseEvent | FocusEvent) => boolean;
   onToggleDock: () => void;
   children: ReactNode;
   dataOpen: boolean;
@@ -32,21 +33,6 @@ export const FloatingPanel = (props: IFloatingPanelProps) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const dockingRef = useRef<HTMLDivElement>(null);
   const hasMounted = useRef(false);
-
-  const handleBlur = useCallback(
-    (e: React.FocusEvent) => {
-      if (
-        !isDocked &&
-        !(ignoreOnBlur ? ignoreOnBlur(e) : false) &&
-        !e.currentTarget.contains(e.relatedTarget as Node) &&
-        !e.relatedTarget?.closest('[data-contextmenu="true"]')
-      ) {
-        onBlur();
-        FocusManager.focusGallery();
-      }
-    },
-    [ignoreOnBlur, isDocked, onBlur],
-  );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -98,6 +84,22 @@ export const FloatingPanel = (props: IFloatingPanelProps) => {
     hasMounted.current = true;
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const handleBlur: ScopeInteractionProps['onOutside'] = useCallback(
+    (e: MouseEvent | FocusEvent) => {
+      if (!isDocked && dataOpen && !(ignoreOnBlur ? ignoreOnBlur(e) : false)) {
+        onBlur();
+        FocusManager.focusGallery();
+      }
+    },
+    [dataOpen, ignoreOnBlur, isDocked, onBlur],
+  );
+
+  useScopeInteraction({
+    currentPath: 'floating-panel',
+    onOutside: handleBlur,
+    elementRef: panelRef,
+  });
+
   return (
     <div ref={dockingRef} id={id} className={className}>
       <div
@@ -107,7 +109,7 @@ export const FloatingPanel = (props: IFloatingPanelProps) => {
         data-animate-flash={dataOpen}
         className={'floating-panel'}
         tabIndex={-1} //necessary for handling the onblur correctly
-        onBlur={handleBlur}
+        //onBlur={handleBlur}
         onKeyDown={handleKeyDown}
       >
         <header onClick={onBlur} id={`${id}-header`}>

--- a/widgets/icons.tsx
+++ b/widgets/icons.tsx
@@ -66,7 +66,7 @@ import LOGO from 'resources/logo/svg/white/allusion-logomark-white.svg';
 import MEDIA from 'resources/icons/media.svg';
 import MENU_HAMBURGER from 'resources/icons/menu-hamburger.svg';
 import META_INFO from 'resources/icons/meta-info.svg';
-// import META_INFO_2 from 'resources/icons/meta-info-2.svg';
+import META_INFO_2 from 'resources/icons/meta-info-2.svg';
 import MORE from 'resources/icons/more.svg';
 import OPEN_EXTERNAL from 'resources/icons/open-external.svg';
 import OUTLINER4 from 'resources/icons/outliner4.svg';
@@ -172,7 +172,7 @@ const IconSet = {
   MEDIA: toSvg(MEDIA),
   MENU_HAMBURGER: toSvg(MENU_HAMBURGER),
   META_INFO: toSvg(META_INFO),
-  // META_INFO_2: toSvg(META_INFO_2),
+  META_INFO_2: toSvg(META_INFO_2),
   MORE: toSvg(MORE),
   OPEN_EXTERNAL: toSvg(OPEN_EXTERNAL),
   PLUS: toSvg(PLUS),

--- a/widgets/slider.tsx
+++ b/widgets/slider.tsx
@@ -1,14 +1,15 @@
-import React, { useCallback, useRef } from 'react';
+import React, { ReactNode, useCallback, useRef } from 'react';
 
 export interface IMenuSliderItem {
   value: number;
-  label?: string;
+  label?: string | ReactNode;
   onChange: (val: number) => void;
   min: number;
   max: number;
   step: number;
   id: string;
   options: { value: number; label?: string }[];
+  secondaryInput?: ReactNode;
 }
 
 export const Slider = ({
@@ -20,6 +21,7 @@ export const Slider = ({
   step,
   id,
   options,
+  secondaryInput,
 }: IMenuSliderItem) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const handleFocus = useCallback(() => inputRef.current?.focus(), []);
@@ -37,7 +39,13 @@ export const Slider = ({
   return (
     <div role="slider-input" tabIndex={-1} onFocus={handleFocus}>
       {label && <label htmlFor={id}>{label}</label>}
-
+      <div
+        onFocus={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        {secondaryInput}
+      </div>
       <div className="slider">
         <input
           type="range"


### PR DESCRIPTION
### New Features
- Added Exif metadata viewer to the inspector and outliner. #96 
  - It allows you to select between the general info or a specific EXIF metadata group of the file.
- Added Inspector with preview image to the main gallery. #123
- Added pagination size configuration under usage preferences. #115
- Added bulk import/export of files metadata when selecting all files. #112
- Added an option to hide many of the buttons that appear in the main toolbar inside the appearance settings.
- Added new hot keys.

### Bug Fixes
- Prevent app crash caused by a race condition when the file watcher detects a new file before the file system finishes writing t.
- Fix visual bug where thumbnails show the new image before updating thumbnail dimensions in the main gallery when changing filters or view.
- Fix a bug where the extra properties were not written to files because the ExifTool config file was not being correctly included in the build. Fixes #78
- Fix deleting files caused scroll position to reset to top. #118
- Fix visual updates in the tag selector
- Added better focus handling to overlay floating panels.