### PR TITLE
Set 'userData' path to executable directory if build is portable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,9 +25,11 @@ import { TagDTO, ROOT_TAG_ID } from './api/tag';
 import { MainMessenger } from './ipc/main';
 import { WindowSystemButtonPress } from './ipc/messages';
 
-// TODO: change this when running in portable mode, see portable-improvements branch
-const basePath = app.getPath('userData');
+// sets the userData path to the executables directory if the installation is portable
+const portablePath = process.env.PORTABLE_EXECUTABLE_DIR as string;
+portablePath && app.setPath('userData', path.join(portablePath, 'Allusion'));
 
+const basePath = app.getPath('userData');
 const preferencesFilePath = path.join(basePath, 'preferences.json');
 const windowStateFilePath = path.join(basePath, 'windowState.json');
 


### PR DESCRIPTION
This pull request aims to improve the portable experience on Windows.
This addresses issue #79 

What this PR does:
The electron build will set the environment variable "PORTABLE_EXECUTABLE_DIR" to the current executable directory if the build is portable. Using this, we can set the 'userData' path to the executables directory. In this case, all files which were previously stored in ".../appdata/roaming/Allusion" will now be stored in ".../[executable_directory]/Allusion". This way, nothing else needs to be changed and the program behaves as expected.

What this PR doesn't do:
Stored paths to folders are still absolute. Which means if Allusion and all images are saved on a external hard drive, and the drive gets assigned another drive letter, it is required to point Allusion to the images folders again.
This can be fixed in a future PR by storing relative paths instead of absolute paths.

To test this feature with a dev build, it is required to set "PORTABLE_EXECUTABLE_DIR" in the launch.json manually to something like "${workspaceFolder}/.portable"
