### PR TITLE
Add hex input to color picker

### DIFF
--- a/src/frontend/containers/Outliner/TagsPanel/ContextMenu.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/ContextMenu.tsx
@@ -11,6 +11,7 @@ import { Action, Factory } from './state';
 import { hexCompare } from 'widgets/utility/color';
 
 const defaultColorOptions = [
+  { title: 'No Color', color: '' },
   { title: 'Eminence', color: '#5f3292' },
   { title: 'Indigo', color: '#5642A6' },
   { title: 'Blue Ribbon', color: '#143ef1' },
@@ -45,34 +46,28 @@ export const ColorPickerMenu = observer(({ tag }: { tag: ClientTag }) => {
         onClick={() => handleChange(color === 'inherit' ? '' : 'inherit')}
       />
       <MenuSubItem text="Pick Color" icon={IconSet.COLOR}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', width: 'min-content', gap: '3px' }}>
-          <HexColorPicker color={color || undefined} onChange={handleChange} />
-          <button
-            key="none"
-            aria-label="No Color"
-            style={{
-              background: 'none',
-              border: '1px solid var(--text-color)',
-              borderRadius: '100%',
-              height: '1rem',
-              width: '1rem',
-            }}
-            onClick={() => handleChange('')}
-          />
+        <HexColorPicker color={color || undefined} onChange={handleChange} />
+        <div id='testId' style={{ display: 'grid', gridTemplateColumns: "repeat(auto-fill, minmax(24px, 1fr))", gap: '2px', marginTop: "4px" }}>
           {defaultColorOptions.map(({ title, color }) => (
-            <button
-              key={title}
-              aria-label={title}
-              style={{
+            <button style={{
                 background: color,
-                border: 'none',
+                border: color === '' ? '1px solid var(--text-color)' : 'none',
                 borderRadius: '100%',
                 height: '1rem',
                 width: '1rem',
+                margin: 0
               }}
+              key={title}
+              aria-label={title}
               onClick={() => handleChange(color)}
             />
           ))}
+          <input value={color} className="input" type="text" style={{gridColumn: "span 2", padding: '1px'}}
+            onChange={(event) => {
+              console.log(event.target.value)
+              handleChange(event.target.value)
+            }}
+          />
         </div>
       </MenuSubItem>
     </>


### PR DESCRIPTION
Implementation of my feature request #135
This refactors the color picker and adds a hex input field to it.
The input field is two way binded and updates as the color is selected.
Additionally, the predefined colors are now spaced evenly to fill the horizontal space.

<img width="411" height="279" alt="grafik" src="https://github.com/user-attachments/assets/da41e7de-239d-4873-9fb1-99434dc7feb0" />
