### PR TITLE
Dev

### DIFF
--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -547,6 +547,15 @@
         // It won't take up more than 1 line due to no-wrap
         height: 2em;
       }
+
+      .thumbnail-filename {
+        cursor: pointer;
+        transition: transform 0.08s ease-in-out;
+
+        &:active {
+          transform: scale(0.96);
+        }
+      }
     }
 
     &:hover {

--- a/resources/style/controls/menu.scss
+++ b/resources/style/controls/menu.scss
@@ -18,6 +18,12 @@
       flex: 1;
       border-bottom: 1px solid var(--text-color-muted);
     }
+
+    .separator-label {
+      margin: 0 0.5rem;
+      color: var(--text-color-muted);
+      white-space: nowrap;
+    }
   }
 
   [role='group'] {

--- a/resources/style/controls/multisplit.scss
+++ b/resources/style/controls/multisplit.scss
@@ -40,7 +40,6 @@
       // height: 100%;
       width: 100%;
       overflow: auto;
-      transition: height 0.1s ease-out;
 
       // workaround for the collapse transition interfering with the flex-grow transition
       > .collapse {

--- a/resources/style/controls/notifications.scss
+++ b/resources/style/controls/notifications.scss
@@ -23,6 +23,7 @@
 }
 
 .toast {
+  position: relative;
   background: var(--accent-color);
   color: white;
   width: 22.5rem;
@@ -34,6 +35,24 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  &.compact {
+    width: auto;
+
+    .btn-minimal {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      opacity: 0;
+      background: transparent;
+      border: none;
+      outline: none;
+      z-index: 2; 
+      cursor: pointer; 
+    }
+  }
 
   &-info {
     background: var(--accent-color-blue);

--- a/resources/style/controls/popover.scss
+++ b/resources/style/controls/popover.scss
@@ -139,6 +139,7 @@ dialog[role='alertdialog'] {
 
   &[data-open='false'] {
     visibility: hidden;
+    display: none;
     pointer-events: none;
   }
 }
@@ -167,6 +168,7 @@ dialog[role='alertdialog'] {
   &[data-open='false'] {
     @keyframes hide {
       from {
+        display: initial;
         visibility: visible;
         opacity: 1;
       }
@@ -174,6 +176,7 @@ dialog[role='alertdialog'] {
       to {
         opacity: 0;
         visibility: hidden;
+        display: none;
       }
     }
     animation: hide 0.1s linear;

--- a/resources/style/inspector.scss
+++ b/resources/style/inspector.scss
@@ -89,7 +89,7 @@
     padding-right: 0.2rem;
   }
 
-  .inspector-extra-porperties-header {
+  header{
     .toolbar-button {
       opacity: 0;
 
@@ -100,11 +100,11 @@
     }
   }
 
-  .inspector-extra-porperties-header > div[tabindex='-1'] > .toolbar-button {
+  header > div[tabindex='-1'] > .toolbar-button {
     justify-content: flex-end;
   }
 
-  &:hover .inspector-extra-porperties-header .toolbar-button  {
+  &:hover header .toolbar-button  {
     opacity: 1;
   }
 }

--- a/resources/style/outliner.scss
+++ b/resources/style/outliner.scss
@@ -241,11 +241,13 @@
 }
 
 .location-properties-dialog,
+.tag-palette-dialog,
 .tag-properties-dialog {
   display: flex;
   flex-direction: column;
 
   #location-properties-dialog-content,
+  #tag-palette-dialog-content,
   #tag-properties-dialog-content {
     width: min(90ch, 80vw);
     max-height: 80vh;
@@ -349,6 +351,242 @@
           display: none;
           pointer-events: none;
         }
+      }
+    }
+  }
+}
+
+.tag-palette-dialog {
+  max-width: 140ch;
+
+  .dialog-header {
+    margin-bottom: 0;
+  }
+
+  #tag-palette-dialog-content {
+    width: min(110ch, 80vw);
+    margin-top: 0;
+    display: flex;
+    gap: 20px;
+    min-height: 400px;
+
+///////////
+
+    .palette-sidebar {
+      width: 32ch;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      border-right: 1px solid var(--border-color);
+      padding-right: 15px;
+      
+      .sidebar-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        span {
+          font-weight: bold;
+        }
+
+        .button.is-compact {
+          padding: 2px 8px;
+          display: flex;
+          align-items: center;
+        }
+      }
+
+      .palette-vertical-list {
+        flex: 1;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 0px;
+
+        .empty-state {
+          opacity: 0.5;
+          font-size: 12px;
+          padding: 8px 0;
+        }
+      }
+
+      .palette-list-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-left: 6px;
+        padding-right: 0;
+        padding-block: 1px;
+        cursor: grab;
+        background-color: transparent;
+        border: 1px solid transparent;
+        transition: background-color 0.1s, border 0.1s, opacity 0.1s;
+        
+        &:hover {
+          background-color: var(--hover-color);
+          color: var(--text-color-strong);
+        }
+
+        &.is-dragging {
+          opacity: 0.4;
+        }
+
+        &.is-selected {
+          background-color: var(--background-color-selected);
+          border: 1px solid var(--accent-color);
+          color: var(--text-color-strong);
+        }
+
+        .palette-name {
+          font-size: 13px;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          user-select: none;
+        }
+
+        .delete-btn {
+          background: transparent;
+          border: none;
+          cursor: pointer;
+          opacity: 0;
+          padding-block: 2px;
+          transition: opacity 0.1s;
+
+          &:hover {
+            opacity: 1;
+          }
+        }
+
+        &:hover .delete-btn {
+          opacity: 0.6;
+        }
+      }
+    }
+
+    .palette-main-editor {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+
+      .empty-editor-state {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        opacity: 0.5;
+      }
+    }
+    
+//////////////////
+
+    fieldset {
+      margin-top: 0.5rem;
+    }
+
+    [role="toolbar"] {
+      gap: 5px;
+
+      select {
+        flex: 1;
+      }
+
+      .palette-index-input{
+        width: 3rem;
+      }
+
+      [data-popover="true"] {
+        ul[role='menu'] {
+          display: block;
+          padding: 0.5rem;
+        }
+      }
+    }
+  }
+}
+
+.tag-Order-Editor {
+  .multiautocomplete-input {
+    width: 100%;
+  }
+
+  // Scoped reset to keep elements tight without changing global layout components
+  .input-wrapper {
+    width: 100%;
+    gap: 1px 0px; // Row gap for multiline, 0px column gap since drop indicators act as structural padding
+    align-items: center;
+  }
+
+  .tag-option-hint {
+    padding: 2px 4px;
+    user-select: none;
+  }
+
+  .draggable-tag-wrapper {
+    display: inline-flex;
+    align-items: center;
+    cursor: grab;
+    user-select: none;
+    transition: opacity 0.12s ease, border 0.12s ease, transform 0.12s ease;
+    border: 2px solid transparent;
+    border-radius: var(--radius-sm, 4px);
+    background-color: transparent;
+
+    .tag {
+      margin: 0;
+    }
+
+    &.selected {
+      border: 2px solid var(--accent-color);
+    }
+
+    &.dragging-source {
+      opacity: 0.35;
+    }
+
+    &.scale-down {
+      transform: scale(0.97);
+    }
+  }
+
+  .drop-indicator {
+    position: relative;
+    display: inline-block;
+    width: 0px;       // Invisible layout width acting as a small gap
+    height: 22px;     // Extended height to match layout lines
+    vertical-align: middle;
+    transition: width 0.1s ease;
+    z-index: 10;
+
+    // The actual visible line indicator is isolated to a clean center anchor
+    &::after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      bottom: 2px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 4px;
+      border-radius: 1px;
+      background-color: transparent;
+      transition: background-color 0.1s ease, width 0.1s ease;
+    }
+
+    // Larger interactive drop hit box expanding horizontally over tag margins
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: -6px;   // Extends hit-detection area to the left
+      right: -6px;  // Extends hit-detection area to the right
+    }
+
+    &.is-drag-over {
+      width: 12px;
+      
+      &::after {
+        width: 6px;
+        background-color: var(--accent-color);
       }
     }
   }

--- a/resources/style/outliner.scss
+++ b/resources/style/outliner.scss
@@ -19,7 +19,7 @@
     opacity: 1;
   }
 
-  &:hover #file-editors-panel-header .toolbar-button  {
+  &:hover #file-editors-panel-header .toolbar-button {
     opacity: 1;
   }
 }
@@ -54,7 +54,7 @@
   position: relative;
   //min-height: 1rem;
   &::after {
-    content: "";
+    content: '';
     position: absolute;
     height: 1rem;
     width: 100%;
@@ -87,13 +87,14 @@
 
   h2 {
     cursor: pointer;
-    flex: 1 1 auto;
+    flex: 1 0 auto;
     white-space: nowrap;
     overflow: hidden;
     line-height: 1.5;
   }
 
   [role='toolbar'] {
+    justify-content: end;
     opacity: 0;
   }
 
@@ -268,8 +269,86 @@
       display: inline-flex;
       flex-wrap: wrap;
 
-      li{
+      li {
         flex: 1 1 auto;
+      }
+    }
+  }
+}
+
+// Tag hierarchy panel extra styles
+.search-tag-bar {
+  // default shrinked style
+  margin-right: 0.4rem;
+  flex-grow: 0;
+  width: 1.15rem;
+  transition: flex-grow 0.3s ease, width 0.3s ease;
+
+  .tag-selector.input {
+    height: 1.25rem;
+    background: transparent;
+    border: transparent;
+    cursor: pointer;
+
+    .multiautocomplete-input {
+      display: flex;
+      align-items: center;
+
+      .input-wrapper {
+        flex-grow: 1;
+
+        input {
+          height: 1.15rem;
+          line-height: 1.15rem;
+          min-height: unset;
+        }
+      }
+
+      .btn-icon {
+        height: 1.15rem;
+        width: 1.15rem;
+        min-height: unset;
+        min-width: unset;
+
+        // hidden by default
+        display: none;
+      }
+
+      .btn-icon-search {
+        height: 1.15rem;
+        width: 1.15rem;
+        display: inline-flex;
+        
+        .custom-icon {
+          height: 0.8rem;
+          width: 0.8rem;
+        }
+      }
+    }
+  }
+
+  // expanded state
+  [role='toolbar']:has(&.expanded) {
+    flex: 1 1 auto;
+  }
+  &.expanded {
+    flex-grow: 1;
+    width: 100%;
+  }
+  // toggle visibility of icon buttons
+  &.expanded{
+    .tag-selector.input {
+      background: var(--input-color);
+      border: 0.0625rem solid var(--border-color);
+
+      .multiautocomplete-input {
+        .btn-icon {
+          display: inline-flex;
+        }
+        .btn-icon-search {
+          display: none;
+          pointer-events: none;
+        }
       }
     }
   }

--- a/resources/style/outliner.scss
+++ b/resources/style/outliner.scss
@@ -113,6 +113,13 @@
   }
 }
 
+header {
+  [data-popover="true"] {
+    font-weight: initial;
+    font-size: small;
+  }
+}
+
 // LIST
 
 .tree-content-label {
@@ -373,7 +380,7 @@
 ///////////
 
     .palette-sidebar {
-      width: 32ch;
+      width: 34ch;
       display: flex;
       flex-direction: column;
       gap: 10px;
@@ -399,6 +406,7 @@
       .palette-vertical-list {
         flex: 1;
         overflow-y: auto;
+        overflow-x: hidden;
         display: flex;
         flex-direction: column;
         gap: 0px;
@@ -421,6 +429,7 @@
         background-color: transparent;
         border: 1px solid transparent;
         transition: background-color 0.1s, border 0.1s, opacity 0.1s;
+        min-width: 0;
         
         &:hover {
           background-color: var(--hover-color);
@@ -438,6 +447,10 @@
         }
 
         .palette-name {
+          overflow: hidden; 
+          flex: 1;
+          padding-block: 0.2rem;
+          min-width: 0;
           font-size: 13px;
           text-overflow: ellipsis;
           white-space: nowrap;
@@ -445,6 +458,7 @@
         }
 
         .delete-btn {
+          flex-shrink: 0;
           background: transparent;
           border: none;
           cursor: pointer;
@@ -502,6 +516,10 @@
       }
     }
   }
+}
+
+.tag-palette-list {
+  max-height: 30ch;
 }
 
 .tag-Order-Editor {

--- a/resources/style/tag-editor.scss
+++ b/resources/style/tag-editor.scss
@@ -7,6 +7,10 @@
   overflow: hidden;
   resize: vertical;
 
+  &[data-docked="true"] {
+    transition: height 0.05s ease-out;
+  }
+
   // Intended layout behavior:
   // - Input element has a static height
   // - The tag checklist expands or shrinks to fill available space

--- a/resources/style/tag-editor.scss
+++ b/resources/style/tag-editor.scss
@@ -6,7 +6,6 @@
   flex-direction: column;
   overflow: hidden;
   resize: vertical;
-  transition: height 0.1s ease-out;
 
   // Intended layout behavior:
   // - Input element has a static height
@@ -42,7 +41,6 @@
     height: calc(1.5rem * 3.5); // 3.5 rows of tags
     //Allow resizing and move the resize handle to the top of the div
     resize: vertical;
-    transition: height 0.1s ease-out;
     transform: scaleY(-1);
     //Important to avoid the main resize handler to overlap with this resize handler
     min-height: 2rem;

--- a/src/api/data-storage.ts
+++ b/src/api/data-storage.ts
@@ -13,6 +13,7 @@ import { LocationDTO } from './location';
 import { TagDTO } from './tag';
 import { ExtraPropertyDTO } from './extraProperty';
 import { BatchFetcher } from 'common/promise';
+import { TagPaletteDTO } from './tagPalette';
 
 /**
  * The user generated persisted data edited or viewed by one or multiple actors (users, multiple devices etc.).
@@ -39,6 +40,7 @@ export interface DataStorage {
   fetchLocations(): Promise<LocationDTO[]>;
   fetchSearches(): Promise<FileSearchDTO[]>;
   fetchExtraProperties(): Promise<ExtraPropertyDTO[]>;
+  fetchTagPalettes(): Promise<TagPaletteDTO[]>;
   searchFiles(
     criteria: ConditionGroupDTO<FileDTO> | undefined,
     order: OrderBy<FileDTO>,
@@ -54,17 +56,20 @@ export interface DataStorage {
   createLocation(location: LocationDTO): Promise<void>;
   createSearch(search: FileSearchDTO): Promise<void>;
   createExtraProperty(extraProperty: ExtraPropertyDTO): Promise<void>;
+  createTagPalette(palette: TagPaletteDTO): Promise<void>;
   saveTag(tag: TagDTO): Promise<void>;
   saveFiles(files: FileDTO[]): Promise<void>;
   saveLocation(location: LocationDTO): Promise<void>;
   saveSearch(search: FileSearchDTO): Promise<void>;
   saveExtraProperty(extraProperty: ExtraPropertyDTO): Promise<void>;
+  saveTagPalette(palette: TagPaletteDTO): Promise<void>;
   removeTags(tags: ID[]): Promise<void>;
   mergeTags(tagToBeRemoved: ID, tagToMergeWith: ID): Promise<void>;
   removeFiles(files: ID[]): Promise<void>;
   removeLocation(location: ID): Promise<void>;
   removeSearch(search: ID): Promise<void>;
   removeExtraProperties(extraProperty: ID[]): Promise<void>;
+  removeTagPalettes(paletteIds: ID[]): Promise<void>;
   addTagsToFiles(tagIds: ID[], criteria?: ConditionGroupDTO<FileDTO>): Promise<void>;
   removeTagsFromFiles(tagIds: ID[], criteria?: ConditionGroupDTO<FileDTO>): Promise<void>;
   clearTagsFromFiles(criteria?: ConditionGroupDTO<FileDTO>): Promise<void>;

--- a/src/api/tagPalette.ts
+++ b/src/api/tagPalette.ts
@@ -1,0 +1,9 @@
+import { ID } from './id';
+
+export type TagPaletteDTO = {
+  id: ID;
+  name: string;
+  index: number;
+  // in this case tags can appear multiple times in a pallete
+  tags: ID[];
+};

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -18,6 +18,8 @@ import {
   FileTags,
   SubTags,
   SearchGroups,
+  TagPalettes,
+  TagPaletteItems,
 } from './schemaTypes';
 import SQLite from 'better-sqlite3';
 import {
@@ -65,6 +67,7 @@ import { ROOT_LOCATIONS_TAG_ID, ROOT_TAG_ID, TagDTO } from 'src/api/tag';
 import { jsonArrayFrom } from 'kysely/helpers/sqlite';
 import { IS_DEV } from 'common/process';
 import { UpdateObject } from 'kysely/dist/cjs/parser/update-set-parser';
+import { TagPaletteDTO } from 'src/api/tagPalette';
 
 // Use to debug perfomance.
 const USE_TIMING_PROXY = IS_DEV;
@@ -566,6 +569,31 @@ export default class Backend implements DataStorage {
     return eProperties;
   }
 
+  async fetchTagPalettes(): Promise<TagPaletteDTO[]> {
+    console.info('SQLite: Fetching tag palettes...');
+    const palettes = await this.#db
+      .selectFrom('tagPalettes')
+      .selectAll('tagPalettes')
+      .select((eb) => [
+        jsonArrayFrom(
+          eb
+            .selectFrom('tagPaletteItems')
+            .select('tagPaletteItems.tagId')
+            .whereRef('tagPaletteItems.paletteId', '=', 'tagPalettes.id')
+            .orderBy('tagPaletteItems.idx'),
+        ).as('items'),
+      ])
+      .orderBy('tagPalettes.idx')
+      .execute();
+
+    return palettes.map((p) => ({
+      id: p.id,
+      name: p.name,
+      index: p.idx,
+      tags: p.items.map((item) => item.tagId),
+    }));
+  }
+
   async createTag(tag: TagDTO): Promise<void> {
     console.info('SQLite: Creating tag...', tag);
     return this.upsertTag(tag);
@@ -612,6 +640,11 @@ export default class Backend implements DataStorage {
   async createExtraProperty(extraProperty: ExtraPropertyDTO): Promise<void> {
     console.info('SQLite: Creating extra property...', extraProperty);
     return this.upsertExtraProperty(extraProperty);
+  }
+
+  async createTagPalette(palette: TagPaletteDTO): Promise<void> {
+    console.info('SQLite: Creating tag palette...', palette);
+    return this.upsertTagPalette(palette);
   }
 
   async saveTag(tag: TagDTO): Promise<void> {
@@ -820,6 +853,31 @@ export default class Backend implements DataStorage {
     this.#notifyChange();
   }
 
+  async saveTagPalette(palette: TagPaletteDTO): Promise<void> {
+    console.info('SQLite: Saving tag palette...', palette);
+    return this.upsertTagPalette(palette);
+  }
+
+  async upsertTagPalette(palette: TagPaletteDTO): Promise<void> {
+    const { paletteIds, tagPalettes, tagPaletteItems } = normalizeTagPalettes([palette]);
+    if (tagPalettes.length === 0) {
+      return;
+    }
+    await this.#db.transaction().execute(async (trx) => {
+      await trx.deleteFrom('tagPaletteItems').where('paletteId', 'in', paletteIds).execute();
+      await upsertTable(this.MAX_VARS, trx, 'tagPalettes', tagPalettes, ['id']);
+      if (tagPaletteItems.length > 0) {
+        await upsertTable(this.MAX_VARS, trx, 'tagPaletteItems', tagPaletteItems, [
+          'paletteId',
+          'tagId',
+          'idx',
+        ]);
+      }
+    });
+
+    this.#notifyChange();
+  }
+
   async mergeTags(tagToBeRemoved: ID, tagToMergeWith: ID): Promise<void> {
     console.info('SQLite: Merging tags...', tagToBeRemoved, tagToMergeWith);
 
@@ -900,6 +958,13 @@ export default class Backend implements DataStorage {
     console.info('SQLite: Removing extra properties...', extraPropertyIDs);
     // Cascade delte in other tables deleting from extraProperties table.
     await this.#db.deleteFrom('extraProperties').where('id', 'in', extraPropertyIDs).execute();
+    this.#notifyChange();
+  }
+
+  async removeTagPalettes(paletteIds: ID[]): Promise<void> {
+    console.info('SQLite: Removing tag palettes...', paletteIds);
+    // Cascade delte in tagPaletteItems deleting from tagPalettes table.
+    await this.#db.deleteFrom('tagPalettes').where('id', 'in', paletteIds).execute();
     this.#notifyChange();
   }
 
@@ -2095,4 +2160,35 @@ function normalizeFiles(sourceFiles: FileDTO[]) {
     }
   }
   return { fileIds, files, fileTags, epVal };
+}
+
+function normalizeTagPalettes(palettesDTO: TagPaletteDTO[]) {
+  const paletteIds: ID[] = [];
+  const tagPalettes: Insertable<TagPalettes>[] = [];
+  const tagPaletteItems: Insertable<TagPaletteItems>[] = [];
+
+  for (const palette of palettesDTO) {
+    paletteIds.push(palette.id);
+    tagPalettes.push({
+      id: palette.id,
+      name: palette.name,
+      idx: palette.index,
+    });
+
+    if (Array.isArray(palette.tags)) {
+      palette.tags.forEach((tagId, idx) => {
+        tagPaletteItems.push({
+          paletteId: palette.id,
+          tagId: tagId,
+          idx: idx,
+        });
+      });
+    }
+  }
+
+  return {
+    paletteIds,
+    tagPalettes,
+    tagPaletteItems,
+  };
 }

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -26,6 +26,7 @@ class InlineMigrationProvider implements MigrationProvider {
       '000_initial': await import('./migrations/000_initial'),
       '001_migrateJSON': (await import('./migrations/001_migrateJSON')).default(context),
       '002_files_add_generated_directory_path': await import('./migrations/002_files_add_generated_directory_path'), // eslint-disable-line prettier/prettier
+      '003_tag_palettes': await import('./migrations/003_tag_palettes'),
     };
   }
 }

--- a/src/backend/migrations/003_tag_palettes.ts
+++ b/src/backend/migrations/003_tag_palettes.ts
@@ -1,0 +1,38 @@
+/* eslint-disable prettier/prettier */
+import { Kysely } from 'kysely';
+
+/*
+Migration to create the Tag Palettes tables.
+SQL table and column names are in snake_case, which will later be converted
+to camelCase by the Kysely camel case plugin.
+*/
+export async function up(db: Kysely<any>): Promise<void> {
+  //// TAG PALETTES ////
+  await db.schema
+    .createTable('tag_palettes')
+    .addColumn('id', 'text', (col) => col.primaryKey().notNull())
+    .addColumn('name', 'text', (col) => col.notNull())
+    .addColumn('idx', 'integer', (col) => col.notNull())
+    .execute();
+
+  await db.schema
+    .createTable('tag_palette_items')
+    .addColumn('palette_id', 'text', (col) => col.notNull())
+    .addColumn('tag_id', 'text', (col) => col.notNull())
+    .addColumn('idx', 'integer', (col) => col.notNull())
+    .addPrimaryKeyConstraint('pk_tag_palette_items', ['palette_id', 'tag_id', 'idx'])
+    .addForeignKeyConstraint('fk_tag_palette_items_palette', ['palette_id'], 'tag_palettes', ['id'], (cb) => cb.onDelete('cascade'))
+    .addForeignKeyConstraint('fk_tag_palette_items_tag', ['tag_id'], 'tags', ['id'], (cb) => cb.onDelete('cascade'))
+    .execute();
+
+  // Indexes
+  await db.schema.createIndex('idx_tag_palette_items_palette').on('tag_palette_items').column('palette_id').execute();
+  await db.schema.createIndex('idx_tag_palette_items_tag').on('tag_palette_items').column('tag_id').execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropIndex('idx_tag_palette_items_tag').execute();
+  await db.schema.dropIndex('idx_tag_palette_items_palette').execute();
+  await db.schema.dropTable('tag_palette_items').execute();
+  await db.schema.dropTable('tag_palettes').execute();
+}

--- a/src/backend/schemaTypes.ts
+++ b/src/backend/schemaTypes.ts
@@ -43,6 +43,8 @@ export type AllusionDB_SQL = {
   savedSearches: SavedSearches;
   searchGroups: SearchGroups;
   searchCriteria: SearchCriteria;
+  tagPalettes: TagPalettes;
+  tagPaletteItems: TagPaletteItems;
 };
 
 ///// TAGS /////
@@ -176,4 +178,18 @@ export type SearchCriteria = {
   // This simplifies the schema (single column) and querying. The type check is managed
   // inside the app logic in the searchStore and thir related api types.
   jsonValue: string;
+};
+
+/// TAG PALETTES ///
+
+export type TagPalettes = {
+  id: ColumnType<ID, ID, never>; // pk
+  name: string;
+  idx: number;
+};
+
+export type TagPaletteItems = {
+  paletteId: ID; // pk fk
+  tagId: ID; // pk fk
+  idx: number; // pk, this allow to have the same tag added multiple times to a pallete.
 };

--- a/src/frontend/components/FileExtraPropertiesEditor.tsx
+++ b/src/frontend/components/FileExtraPropertiesEditor.tsx
@@ -251,7 +251,7 @@ interface PortalButtonWrapperProps {
   onPortalCreation?: () => void;
 }
 
-const PortalButtonWrapper = ({
+export const PortalButtonWrapper = ({
   containerId,
   children,
   onPortalCreation,

--- a/src/frontend/components/FileExtraPropertiesEditor.tsx
+++ b/src/frontend/components/FileExtraPropertiesEditor.tsx
@@ -6,7 +6,7 @@ import { useStore } from '../contexts/StoreContext';
 import { Menu, MenuButton, useContextMenu } from 'widgets/menus';
 import { ClientExtraProperty } from '../entities/ExtraProperty';
 import { FileExtraPropertyMenuItems } from '../containers/ContentView/menu-items';
-import { useAutorun, useComputed } from '../hooks/mobx';
+import { useComputed } from '../hooks/mobx';
 import { ExtraPropertySelector } from './ExtraPropertySelector';
 import { ClientFile } from '../entities/File';
 import { IComputedValue, runInAction } from 'mobx';
@@ -23,6 +23,7 @@ import { useGalleryInputKeydownHandler } from '../hooks/useHandleInputKeydown';
 import { ExtraPropertyType, ExtraPropertyValue } from 'src/api/extraProperty';
 import { createPortal } from 'react-dom';
 import { Placement } from '@floating-ui/core';
+import useMountState from '../hooks/useMountState';
 
 const PANEL_HEIGHT_ID = 'extra-properties-editor-height';
 
@@ -133,16 +134,18 @@ export const FileExtraPropertiesEditor = observer(
       onRenameExtraProperty: onRename,
     });
 
-    // Autofocus
+    // Autofocus on mount
     const buttonParentRef = useRef<HTMLDivElement>(null);
     const focusButton = useRef(() => {
       requestAnimationFrame(() => requestAnimationFrame(() => buttonParentRef.current?.focus()));
     }).current;
-    useAutorun(() => {
-      if (uiStore.isFileExtraPropertiesEditorOpen) {
+    const [isMounted] = useMountState();
+    useEffect(() => {
+      if (isMounted) {
         focusButton();
       }
-    });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isMounted]);
 
     //resize
     const panelRef = useRef<HTMLDivElement>(null);

--- a/src/frontend/components/FileTag.tsx
+++ b/src/frontend/components/FileTag.tsx
@@ -70,6 +70,7 @@ const FileTags = observer(({ file }: IFileTagProp) => {
       renderCreateOption={renderCreateOption}
       showTagContextMenu={handleTagContextMenu}
       multiline
+      disableTagPalletes={false}
     />
   );
 });

--- a/src/frontend/components/FileTagsEditor/index.tsx
+++ b/src/frontend/components/FileTagsEditor/index.tsx
@@ -32,6 +32,9 @@ import useNormaltaggingMode from './useNormaltaggingMode';
 import useBulkTaggingMode, { BulkTag, isBulkText } from './useBulkTaggingMode';
 import { useScopeInteraction } from 'src/frontend/hooks/useScopeInteraction';
 import FocusManager from 'src/frontend/FocusManager';
+import { PortalButtonWrapper } from '../FileExtraPropertiesEditor';
+import TagSelectorSettingsButton from '../TagSelectorSettingsButton';
+import { FILE_EDITOR_HEADER_ID } from 'src/frontend/containers/Outliner/FileEditorsPanel';
 
 const POPUP_ID = 'tag-editor-popup';
 const PANEL_SIZE_ID = 'tag-editor-height';
@@ -230,51 +233,60 @@ export const FileTagsEditor = observer(() => {
   const handleTagContextMenu = TagSummaryMenu();
 
   return (
-    <div
-      ref={panelRef}
-      id="tag-editor"
-      style={{ height: storedHeight ?? undefined }}
-      role="combobox"
-      data-docked={uiStore.areFileEditorsDocked}
-      aria-haspopup="grid"
-      aria-expanded="true"
-      aria-owns={POPUP_ID}
-    >
-      <input
-        type="text"
-        spellCheck={false}
-        value={inputText}
-        aria-autocomplete="list"
-        onChange={handleInput}
-        onPaste={handlePaste}
-        onKeyDown={handleKeyDown}
-        className="input"
-        aria-controls={POPUP_ID}
-        aria-activedescendant={activeDescendant}
-        ref={inputRef}
-      />
-      <MatchingTagsList
-        ref={gridRef}
-        inputText={dobuncedQuery}
-        getTabMatchTagRef={getTabMatchTagRef}
-        counter={counter}
-        resetTextBox={resetTextBox}
-        onContextMenu={handleTagContextMenu}
-      />
-      <div ref={summaryRef} style={{ height: storedSummaryHeight ?? undefined }}>
-        {uiStore.fileSelection.size === 0 ? (
-          <div><i><b>No files selected</b></i></div> // eslint-disable-line prettier/prettier
-        ) : (
-          showSummary && (
-            <TagSummary
-              counter={counter}
-              removeTag={removeTag}
-              onContextMenu={handleTagContextMenu}
-            />
-          )
-        )}
+    <>
+      <PortalButtonWrapper containerId={FILE_EDITOR_HEADER_ID}>
+        <TagSelectorSettingsButton />
+      </PortalButtonWrapper>
+      <div
+        ref={panelRef}
+        id="tag-editor"
+        style={{ height: storedHeight ?? undefined }}
+        role="combobox"
+        data-docked={uiStore.areFileEditorsDocked}
+        aria-haspopup="grid"
+        aria-expanded="true"
+        aria-owns={POPUP_ID}
+      >
+        <input
+          type="text"
+          spellCheck={false}
+          value={inputText}
+          aria-autocomplete="list"
+          onChange={handleInput}
+          onPaste={handlePaste}
+          onKeyDown={handleKeyDown}
+          className="input"
+          aria-controls={POPUP_ID}
+          aria-activedescendant={activeDescendant}
+          ref={inputRef}
+        />
+        <MatchingTagsList
+          ref={gridRef}
+          inputText={dobuncedQuery}
+          getTabMatchTagRef={getTabMatchTagRef}
+          counter={counter}
+          resetTextBox={resetTextBox}
+          onContextMenu={handleTagContextMenu}
+        />
+        <div ref={summaryRef} style={{ height: storedSummaryHeight ?? undefined }}>
+          {uiStore.fileSelection.size === 0 ? (
+            <div>
+              <i>
+                <b>No files selected</b>
+              </i>
+            </div> // eslint-disable-line prettier/prettier
+          ) : (
+            showSummary && (
+              <TagSummary
+                counter={counter}
+                removeTag={removeTag}
+                onContextMenu={handleTagContextMenu}
+              />
+            )
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 });
 
@@ -376,8 +388,11 @@ const TagSummary = observer(({ counter, removeTag, onContextMenu }: TagSummaryPr
         onContextMenu={onContextMenu}
         chunkSize={uiStore.fileSelection.size > 1 ? 5 : 100}
       />
-      {sortedTags.length === 0 && <i><b>No tags added yet</b></i> // eslint-disable-line prettier/prettier
-      }
+      {sortedTags.length === 0 && (
+        <i>
+          <b>No tags added yet</b>
+        </i>
+      )}
     </div>
   );
 });

--- a/src/frontend/components/FileTagsEditor/index.tsx
+++ b/src/frontend/components/FileTagsEditor/index.tsx
@@ -235,6 +235,7 @@ export const FileTagsEditor = observer(() => {
       id="tag-editor"
       style={{ height: storedHeight ?? undefined }}
       role="combobox"
+      data-docked={uiStore.areFileEditorsDocked}
       aria-haspopup="grid"
       aria-expanded="true"
       aria-owns={POPUP_ID}

--- a/src/frontend/components/FileTagsEditor/index.tsx
+++ b/src/frontend/components/FileTagsEditor/index.tsx
@@ -30,6 +30,8 @@ import useFocusEnforcer from '../../hooks/useFocusEnforcer';
 import { BULK_APPLY_OPTION, CREATE_OPTION } from './specialOptions';
 import useNormaltaggingMode from './useNormaltaggingMode';
 import useBulkTaggingMode, { BulkTag, isBulkText } from './useBulkTaggingMode';
+import { useScopeInteraction } from 'src/frontend/hooks/useScopeInteraction';
+import FocusManager from 'src/frontend/FocusManager';
 
 const POPUP_ID = 'tag-editor-popup';
 const PANEL_SIZE_ID = 'tag-editor-height';
@@ -225,7 +227,7 @@ export const FileTagsEditor = observer(() => {
     onFocusLost: resetTextBox,
   });
 
-  const handleTagContextMenu = TagSummaryMenu({ parentPopoverId: 'tag-editor' });
+  const handleTagContextMenu = TagSummaryMenu();
 
   return (
     <div
@@ -457,55 +459,21 @@ export const IncrementalTagItems = observer((props: IncrementalTagItemsProps) =>
   );
 });
 
-interface ITagSummaryMenu {
-  parentPopoverId: string;
-}
-
-const TagSummaryMenu = ({ parentPopoverId }: ITagSummaryMenu) => {
-  const getFocusableElement = useCallback(() => {
-    return document
-      .getElementById(parentPopoverId)
-      ?.querySelector('input, textarea, button, a, select, [tabindex]') as HTMLElement | null;
-  }, [parentPopoverId]);
-  const handleMenuBlur = useCallback(
-    (e: React.FocusEvent) => {
-      if (!e.relatedTarget?.closest('[data-popover="true"]')) {
-        const element = getFocusableElement();
-        if (element && element instanceof HTMLElement) {
-          element.focus();
-          element.blur();
-        }
-      }
-    },
-    [getFocusableElement],
-  );
-  const handleMenuKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        const element = getFocusableElement();
-        e.stopPropagation();
-        if (element && element instanceof HTMLElement) {
-          element.focus();
-          element.blur();
-        }
-      }
-    },
-    [getFocusableElement],
-  );
-  const beforeSelect = useCallback(() => {
-    const element = getFocusableElement();
-    if (element && element instanceof HTMLElement) {
-      element.focus();
-      element.blur();
-    }
-  }, [getFocusableElement]);
-  const [activeMenuId, setActiveMenuId] = useState<string | null>(null);
+const TagSummaryMenu = () => {
   const divRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (activeMenuId && divRef.current) {
-      divRef.current.focus();
-    }
-  }, [activeMenuId]);
+  const beforeSelect = useCallback(() => {
+    FocusManager.focusGallery();
+  }, []);
+  const handleClose = useCallback(() => {
+    divRef.current?.focus();
+    divRef.current?.blur();
+  }, []);
+
+  useScopeInteraction({
+    currentPath: 'floating-panel/file-tags-editor/tag-menu',
+    onOutside: handleClose,
+    elementRef: divRef,
+  });
 
   const show = useContextMenu();
   const handleTagContextMenu = useCallback(
@@ -514,15 +482,14 @@ const TagSummaryMenu = ({ parentPopoverId }: ITagSummaryMenu) => {
       show(
         event.clientX,
         event.clientY,
-        <div ref={divRef} onBlur={handleMenuBlur} onKeyDown={handleMenuKeyDown} tabIndex={-1}>
+        <div ref={divRef} tabIndex={-1}>
           <Menu>
             <EditorTagSummaryItems tag={tag} beforeSelect={beforeSelect} />
           </Menu>
         </div>,
       );
-      setActiveMenuId(tag.id);
     },
-    [show, handleMenuBlur, handleMenuKeyDown, beforeSelect],
+    [show, beforeSelect],
   );
 
   return handleTagContextMenu;

--- a/src/frontend/components/FileTagsEditor/useNormaltaggingMode.tsx
+++ b/src/frontend/components/FileTagsEditor/useNormaltaggingMode.tsx
@@ -37,17 +37,18 @@ const useNormaltaggingMode = ({
   resetTextBox,
   onContextMenu,
 }: useNormaltaggingModeProps) => {
-  const { tagStore, uiStore } = useStore();
+  const { tagStore, uiStore, tagPaletteStore } = useStore();
 
   const { matches, widestItem } = useMemo(
     () =>
       computed(
         (): { matches: (string | symbol | ClientTag)[]; widestItem: ClientTag | undefined } => {
+          const activePallete = tagPaletteStore.activePallete; // also works to avoid mobx alerts
+          const usePalette = activePallete !== undefined;
           if (!active) {
-            uiStore.recentlyUsedTags.length; // dummy oversable read to avoid mobx alerts
             return { matches: [], widestItem: undefined };
           }
-          if (inputText.length === 0) {
+          if (!usePalette && inputText.length === 0) {
             let widest: ClientTag | undefined = undefined;
             // string matches creates separators
             const matches: (symbol | ClientTag | string)[] = [];
@@ -70,13 +71,14 @@ const useNormaltaggingMode = ({
             matches.push(CREATE_OPTION);
             return { matches: matches, widestItem: widest };
           } else {
-            const includeSubtags = uiStore.isIncludeSubtagsOnMatchEnabled;
+            const includeSubtags = !usePalette && uiStore.isIncludeSubtagsOnMatchEnabled;
             let widest: ClientTag | undefined = undefined;
             const normalizedInput = normalizeBase(inputText);
             const exactMatches: ClientTag[] = [];
             const otherMatches: ClientTag[] = [];
             const visited = new Set<ClientTag>();
-            for (const tag of tagStore.tagList) {
+            const activeTagList = activePallete?.tags ?? tagStore.tagList;
+            for (const tag of activeTagList) {
               if (includeSubtags && visited.has(tag)) {
                 continue;
               }
@@ -97,13 +99,17 @@ const useNormaltaggingMode = ({
             }
             // Bring exact matches to the top of the suggestions. This helps find tags with short names
             // that would otherwise get buried under partial matches if they appeared lower in the list.
-            // Always append CREATE_OPTION to render the create option component.
+            // if no tag pallete is used, append CREATE_OPTION to render the create option component.
             const createOptionMatches =
               exactMatches.length > 0 || otherMatches.length > 0
                 ? ['', CREATE_OPTION]
                 : [CREATE_OPTION];
             return {
-              matches: [...exactMatches, ...otherMatches, ...createOptionMatches],
+              matches: [
+                ...exactMatches,
+                ...otherMatches,
+                ...(!usePalette ? createOptionMatches : []),
+              ],
               widestItem: widest,
             };
           }
@@ -113,9 +119,10 @@ const useNormaltaggingMode = ({
       active,
       counter,
       inputText,
+      tagPaletteStore.activePallete,
       tagStore.tagList,
-      uiStore.recentlyUsedTags,
       uiStore.isIncludeSubtagsOnMatchEnabled,
+      uiStore.recentlyUsedTags,
     ],
   ).get();
 

--- a/src/frontend/components/TagOrderEditor.tsx
+++ b/src/frontend/components/TagOrderEditor.tsx
@@ -1,0 +1,198 @@
+import { observer } from 'mobx-react-lite';
+import React, { useState, useCallback } from 'react';
+import { Tag } from 'widgets';
+import { ClientTag } from '../entities/Tag';
+
+export interface TagOrderEditorProps {
+  selection: ClientTag[];
+  /** Exposes a Set of position indices and the target layout insertion index */
+  onMoveSelection: (selectedIndices: Set<number>, targetIndex: number) => void;
+  onRemoveTag?: (tag: ClientTag, index: number) => void;
+  onBackgroundClick?: () => void;
+  multiline?: boolean;
+}
+
+export const TagOrderEditor = observer((props: TagOrderEditorProps) => {
+  const {
+    selection: _selection,
+    onMoveSelection,
+    onRemoveTag,
+    onBackgroundClick,
+    multiline,
+  } = props;
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
+  const selection = _selection.slice();
+  // Handles selection including Shift, Ctrl, and Cmd key modifiers
+  const handleTagClick = useCallback(
+    (index: number, e: React.MouseEvent) => {
+      e.stopPropagation();
+
+      const isCmdOrCtrl = e.metaKey || e.ctrlKey;
+      const isShift = e.shiftKey;
+
+      setSelectedIndices((prev) => {
+        const next = new Set(prev);
+
+        // Range multi-selection using Shift modifier
+        if (isShift && lastSelectedIndex !== null) {
+          const start = Math.min(lastSelectedIndex, index);
+          const end = Math.max(lastSelectedIndex, index);
+
+          if (!isCmdOrCtrl) {
+            next.clear();
+          }
+
+          for (let i = start; i <= end; i++) {
+            next.add(i);
+          }
+        }
+        // Granular toggle using Ctrl or Cmd modifier
+        else if (isCmdOrCtrl) {
+          if (next.has(index)) {
+            next.delete(index);
+          } else {
+            next.add(index);
+          }
+        }
+        // Default click behavior (Resets selection pool to the targeted element exclusively)
+        else {
+          next.clear();
+          next.add(index);
+        }
+
+        return next;
+      });
+      setLastSelectedIndex(index);
+    },
+    [lastSelectedIndex],
+  );
+
+  const handleDragStart = useCallback(
+    (index: number, e: React.DragEvent) => {
+      if (!selectedIndices.has(index)) {
+        setSelectedIndices(new Set([index]));
+        setLastSelectedIndex(index);
+      }
+
+      setDraggedIndex(index);
+      e.dataTransfer.setData('text/plain', String(index));
+      e.dataTransfer.effectAllowed = 'move';
+    },
+    [selectedIndices],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedIndex(null);
+  }, []);
+
+  const handleDrop = useCallback(
+    (targetIndex: number, e: React.DragEvent) => {
+      e.preventDefault();
+      if (selectedIndices.size > 0) {
+        onMoveSelection(selectedIndices, targetIndex);
+        setSelectedIndices(new Set());
+        setLastSelectedIndex(null);
+      }
+      setDraggedIndex(null);
+    },
+    [selectedIndices, onMoveSelection],
+  );
+
+  return (
+    <div
+      className={`tag-Order-Editor tag-selector input multiautocomplete dnd-order-mode ${
+        multiline ? 'multiline' : ''
+      }`}
+    >
+      <div className="multiautocomplete-input">
+        <div
+          className="input-wrapper"
+          onClick={onBackgroundClick}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            // Check if the drop target is the wrapper background container itself
+            if (e.target === e.currentTarget && selectedIndices.size > 0) {
+              e.preventDefault();
+              // Target index is set to selection.length to append items at the very end
+              onMoveSelection(selectedIndices, selection.length);
+              setSelectedIndices(new Set());
+              setLastSelectedIndex(null);
+              setDraggedIndex(null);
+            }
+          }}
+        >
+          {selection.length === 0 ? (
+            <span className="">No tags available to reorder.</span>
+          ) : (
+            <>
+              {/* Initial drop boundary offset indicator (Index position 0) */}
+              <DropIndicator index={0} onDrop={handleDrop} />
+
+              {selection.map((tag, index) => {
+                const isSelected = selectedIndices.has(index);
+                const isCurrentDragSource = draggedIndex === index;
+                const dynamicScaleDown =
+                  isSelected && draggedIndex !== null && !isCurrentDragSource;
+                const wrapperClasses = [
+                  'draggable-tag-wrapper',
+                  isSelected ? 'selected' : '',
+                  isCurrentDragSource ? 'dragging-source' : '',
+                  dynamicScaleDown ? 'scale-down' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ');
+
+                return (
+                  <React.Fragment key={`${tag.id}-${index}`}>
+                    <div
+                      draggable
+                      onDragStart={(e) => handleDragStart(index, e)}
+                      onDragEnd={handleDragEnd}
+                      onClick={(e) => handleTagClick(index, e)}
+                      className={wrapperClasses}
+                    >
+                      <Tag
+                        text={tag.name}
+                        color={tag.viewColor}
+                        isHeader={tag.isHeader}
+                        onRemove={onRemoveTag ? () => onRemoveTag(tag, index) : undefined}
+                      />
+                    </div>
+                    {/* Appended inline drop boundary zone mapping directly to index positional offsets */}
+                    <DropIndicator index={index + 1} onDrop={handleDrop} />
+                  </React.Fragment>
+                );
+              })}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+interface DropIndicatorProps {
+  index: number;
+  onDrop: (targetIndex: number, e: React.DragEvent) => void;
+}
+
+const DropIndicator = ({ index, onDrop }: DropIndicatorProps) => {
+  const [isOver, setIsOver] = useState(false);
+
+  return (
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        setIsOver(true);
+      }}
+      onDragLeave={() => setIsOver(false)}
+      onDrop={(e) => {
+        setIsOver(false);
+        onDrop(index, e);
+      }}
+      className={`drop-indicator ${isOver ? 'is-drag-over' : ''}`}
+    />
+  );
+};

--- a/src/frontend/components/TagSelector.tsx
+++ b/src/frontend/components/TagSelector.tsx
@@ -50,6 +50,7 @@ export interface TagSelectorProps {
   fallbackPlacements?: Placement[];
   strat?: Strategy;
   clearInputOnSelect?: boolean;
+  disableTagPalletes?: boolean;
 }
 
 const DEFAULT_FALLBACK_PLACEMENTS: Placement[] = ['left-end', 'top-start', 'right-end'];
@@ -76,6 +77,7 @@ const _TagSelector = forwardRef<HTMLInputElement, TagSelectorProps>(function Tar
     fallbackPlacements = DEFAULT_FALLBACK_PLACEMENTS,
     strat,
     clearInputOnSelect = uiStore.isClearTagSelectorsOnSelectEnabled,
+    disableTagPalletes = true,
   } = props;
   uiStore.isClearTagSelectorsOnSelectEnabled; // avoid mobx unused observer warning
   const gridId = useId();
@@ -291,6 +293,7 @@ const _TagSelector = forwardRef<HTMLInputElement, TagSelectorProps>(function Tar
           resetTextBox={resetTextBox}
           renderCreateOption={renderCreateOption}
           forceCreateOption={forceCreateOption}
+          disableTagPalletes={disableTagPalletes}
         />
       </Flyout>
     </div>
@@ -333,6 +336,7 @@ interface SuggestedTagsListProps {
     resetTextBox: () => void,
   ) => ReactElement<RowProps> | ReactElement<RowProps>[];
   forceCreateOption?: boolean;
+  disableTagPalletes?: boolean;
 }
 
 const SuggestedTagsList = observer(
@@ -350,13 +354,16 @@ const SuggestedTagsList = observer(
       resetTextBox,
       renderCreateOption,
       forceCreateOption,
+      disableTagPalletes = true,
     } = props;
-    const { tagStore, uiStore } = useStore();
+    const { tagStore, uiStore, tagPaletteStore } = useStore();
 
     const { suggestions, widestItem } = useMemo(
       () =>
         computed(() => {
-          if (query.length === 0 && !forceCreateOption) {
+          const activePallete = disableTagPalletes ? undefined : tagPaletteStore.activePallete;
+          const usePalette = activePallete !== undefined;
+          if (!usePalette && query.length === 0 && !forceCreateOption) {
             let widest: ClientTag | undefined = undefined;
             const matches: (ClientTag | ReactElement<RowProps> | string)[] = [];
             // Add recently used tags.
@@ -381,14 +388,15 @@ const SuggestedTagsList = observer(
             }
             return { suggestions: matches, widestItem: widest };
           } else {
-            const includeSubtags = uiStore.isIncludeSubtagsOnMatchEnabled;
+            const includeSubtags = !usePalette && uiStore.isIncludeSubtagsOnMatchEnabled;
             let widest: ClientTag | undefined = undefined;
             const normalizedQuery = normalizeBase(query);
             const exactMatches: ClientTag[] = [];
             const otherMatches: ClientTag[] = [];
             const visited = new Set<ClientTag>();
-            if (!forceCreateOption) {
-              for (const tag of tagStore.tagList) {
+            if (!forceCreateOption || usePalette) {
+              const activeTagList = activePallete?.tags ?? tagStore.tagList;
+              for (const tag of activeTagList) {
                 if (includeSubtags && visited.has(tag)) {
                   continue;
                 }
@@ -429,7 +437,11 @@ const SuggestedTagsList = observer(
             // Bring exact matches to the top of the suggestions. This helps find tags with short names
             // that would otherwise get buried under partial matches if they appeared lower in the list.
             return {
-              suggestions: [...exactMatches, ...otherMatches, ...createOptionItems],
+              suggestions: [
+                ...exactMatches,
+                ...otherMatches,
+                ...(!usePalette ? createOptionItems : []),
+              ],
               widestItem: widest,
             };
           }
@@ -439,6 +451,7 @@ const SuggestedTagsList = observer(
         query,
         tagStore.tagList,
         uiStore.recentlyUsedTags,
+        tagPaletteStore.activePallete,
         renderCreateOption,
         filter,
         forceCreateOption,

--- a/src/frontend/components/TagSelector.tsx
+++ b/src/frontend/components/TagSelector.tsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react-lite';
 import React, {
   ForwardedRef,
+  forwardRef,
   ReactElement,
   useCallback,
   useEffect,
@@ -48,11 +49,15 @@ export interface TagSelectorProps {
   placement?: Placement;
   fallbackPlacements?: Placement[];
   strat?: Strategy;
+  clearInputOnSelect?: boolean;
 }
 
 const DEFAULT_FALLBACK_PLACEMENTS: Placement[] = ['left-end', 'top-start', 'right-end'];
 
-const TagSelector = observer((props: TagSelectorProps) => {
+const _TagSelector = forwardRef<HTMLInputElement, TagSelectorProps>(function TargetTagSelector(
+  props,
+  ref,
+) {
   const { uiStore } = useStore();
   const {
     selection,
@@ -70,14 +75,26 @@ const TagSelector = observer((props: TagSelectorProps) => {
     placement = 'bottom-start',
     fallbackPlacements = DEFAULT_FALLBACK_PLACEMENTS,
     strat,
+    clearInputOnSelect = uiStore.isClearTagSelectorsOnSelectEnabled,
   } = props;
-  const clearInputOnSelect = uiStore.isClearTagSelectorsOnSelectEnabled;
   const gridId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [forceCreateOption, setForceCreateOption] = useState(false);
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebQuery] = useState('');
+
+  const setInputRef = (element: HTMLInputElement | null) => {
+    (inputRef as React.MutableRefObject<HTMLInputElement | null>).current = element;
+    if (!ref) {
+      return;
+    }
+    if (typeof ref === 'function') {
+      ref(element);
+    } else {
+      (ref as React.MutableRefObject<HTMLInputElement | null>).current = element;
+    }
+  };
 
   /**
    * A memoized map of selected tags with their inheritance status for better perfomance.
@@ -252,7 +269,7 @@ const TagSelector = observer((props: TagSelectorProps) => {
                 onKeyUp={handleKeyUp}
                 aria-controls={gridId}
                 aria-activedescendant={activeDescendant}
-                ref={inputRef}
+                ref={setInputRef}
                 onFocus={handleFocus}
               />
             </div>
@@ -277,7 +294,7 @@ const TagSelector = observer((props: TagSelectorProps) => {
     </div>
   );
 });
-
+const TagSelector = observer(_TagSelector);
 export { TagSelector };
 
 interface SelectedTagProps {

--- a/src/frontend/components/TagSelector.tsx
+++ b/src/frontend/components/TagSelector.tsx
@@ -77,6 +77,7 @@ const _TagSelector = forwardRef<HTMLInputElement, TagSelectorProps>(function Tar
     strat,
     clearInputOnSelect = uiStore.isClearTagSelectorsOnSelectEnabled,
   } = props;
+  uiStore.isClearTagSelectorsOnSelectEnabled; // avoid mobx unused observer warning
   const gridId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -107,7 +108,8 @@ const _TagSelector = forwardRef<HTMLInputElement, TagSelectorProps>(function Tar
     } else {
       return new Map((selection as ClientTag[]).map((tag) => [tag, true]));
     }
-  }, [selection]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selection, selection.length]);
 
   const debounceSetDebQuery = useRef(debounce(setDebQuery)).current;
   useEffect(() => {

--- a/src/frontend/components/TagSelectorSettingsButton.tsx
+++ b/src/frontend/components/TagSelectorSettingsButton.tsx
@@ -1,0 +1,85 @@
+import React, { useId } from 'react';
+import { IconSet } from 'widgets/icons';
+import {
+  MenuButton,
+  MenuCheckboxItem,
+  MenuDivider,
+  MenuItem,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSubItem,
+} from 'widgets/menus';
+import { useStore } from '../contexts/StoreContext';
+import { observer } from 'mobx-react-lite';
+
+const TagSelectorSettingsButton = observer(() => {
+  const { uiStore, tagPaletteStore } = useStore();
+  const id = useId();
+  return (
+    <MenuButton
+      icon={IconSet.SETTINGS}
+      text=""
+      id={id}
+      menuID={`${id}-menu`}
+      tooltip="Tag Selector Settings"
+      placement="bottom-start"
+      strategy="fixed"
+    >
+      <MenuSubItem text="Tag List Source" icon={IconSet.TAG_GROUP}>
+        <MenuRadioGroup>
+          <MenuRadioItem
+            icon={IconSet.VIEW_LIST}
+            text="All Tags"
+            checked={tagPaletteStore.activePallete === undefined}
+            onClick={() => tagPaletteStore.setActivePallete(undefined)}
+          />
+          <MenuDivider label="Tag Palettes" />
+          <div className="tag-palette-list config-scrollbar">
+            {tagPaletteStore.paletteList.length > 0 ? (
+              <>
+                {tagPaletteStore.paletteList.map((palette) => (
+                  <MenuRadioItem
+                    key={palette.id}
+                    icon={IconSet.TREE_LIST}
+                    text={palette.name}
+                    checked={tagPaletteStore.activePallete?.id === palette.id}
+                    onClick={() => tagPaletteStore.setActivePallete(palette)}
+                  />
+                ))}
+              </>
+            ) : (
+              <MenuItem
+                icon={IconSet.TAG_GROUP_OPEN}
+                text="Add New Tag Palette"
+                onClick={async () => {
+                  const newPalette = await tagPaletteStore.createPalette('New Tag Palette 1');
+                  tagPaletteStore.setActivePallete(newPalette);
+                  uiStore.openTagPaletteEditor();
+                }}
+              />
+            )}
+          </div>
+        </MenuRadioGroup>
+      </MenuSubItem>
+      <MenuItem
+        icon={IconSet.TAG_GROUP_OPEN}
+        text="Manage Tag Palettes"
+        onClick={uiStore.toggleTagPaletteEditor}
+      />
+      <MenuCheckboxItem
+        text="Clear Tag Search Text After Select"
+        //accelerator={IconSet.SETTINGS}
+        checked={uiStore.isClearTagSelectorsOnSelectEnabled}
+        onClick={uiStore.toggleClearTagSelectorsOnSelect}
+      />
+      <MenuCheckboxItem
+        text="Include Sub-tags On Suggestion Matches"
+        //accelerator={IconSet.SETTINGS}
+        checked={uiStore.isIncludeSubtagsOnMatchEnabled}
+        onClick={uiStore.toggleIncludeSubtagsOnMatch}
+      />
+    </MenuButton>
+  );
+});
+
+export default TagSelectorSettingsButton;

--- a/src/frontend/components/TagSelectorSettingsButton.tsx
+++ b/src/frontend/components/TagSelectorSettingsButton.tsx
@@ -73,7 +73,7 @@ const TagSelectorSettingsButton = observer(() => {
         onClick={uiStore.toggleClearTagSelectorsOnSelect}
       />
       <MenuCheckboxItem
-        text="Include Sub-tags On Suggestion Matches"
+        text="Include Sub-tags In Suggestion Matches"
         //accelerator={IconSet.SETTINGS}
         checked={uiStore.isIncludeSubtagsOnMatchEnabled}
         onClick={uiStore.toggleIncludeSubtagsOnMatch}

--- a/src/frontend/components/Toaster.tsx
+++ b/src/frontend/components/Toaster.tsx
@@ -64,13 +64,14 @@ export interface IToastProps {
   };
   timeout: number;
   type?: 'info' | 'success' | 'warning' | 'error';
+  compact?: boolean;
 }
 
 type IdentifiableToast = IToastProps & { id: ID };
 
 export const Toaster = observer(() => (
   <div id="toast-container">
-    {AppToaster.toastList.map(({ id, message, clickAction, timeout, type = "info" }) => (
+    {AppToaster.toastList.map(({ id, message, clickAction, timeout, type = 'info', compact }) => (
       <Toast
         key={id}
         message={message}
@@ -80,6 +81,7 @@ export const Toaster = observer(() => (
         timeout={timeout}
         onDismiss={() => AppToaster.dismiss(id)}
         type={type}
+        compact={compact}
       />
     ))}
     <SavingIndicator />

--- a/src/frontend/containers/AppToolbar/Menus.tsx
+++ b/src/frontend/containers/AppToolbar/Menus.tsx
@@ -147,6 +147,7 @@ export const SortMenuItems = observer(() => {
   );
 });
 
+// Min and max must match with uiStore min and max thumnail size
 const thumbnailSizeOptions = [
   { value: 128 },
   { value: 208, label: 'Small' },

--- a/src/frontend/containers/ContentView/GalleryItem.tsx
+++ b/src/frontend/containers/ContentView/GalleryItem.tsx
@@ -352,10 +352,18 @@ const ThumbnailOverlay = ({
     file.height
   }, ${humanFileSize(file.size)}`;
 
+  const handleCopyName: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    e.stopPropagation();
+    const nameWithoutExtension = file.name.replace(/\.[^/.]+$/, '');
+    navigator.clipboard.writeText(nameWithoutExtension).catch((err) => {
+      console.error('error on copy file name:', err);
+    });
+  };
+
   return (
     <div className="thumbnail-overlay" data-tooltip={title} tabIndex={-1} onBlur={deselect}>
       {showFilename && (
-        <div className="thumbnail-filename" data-tooltip={title}>
+        <div className="thumbnail-filename" data-tooltip={title} onClick={handleCopyName}>
           {file.name}
         </div>
       )}

--- a/src/frontend/containers/ContentView/LayoutSwitcher.tsx
+++ b/src/frontend/containers/ContentView/LayoutSwitcher.tsx
@@ -86,6 +86,7 @@ const Layout = ({ contentRect }: LayoutProps) => {
       if (uiStore.isSlideMode) {
         return;
       }
+      let clearSelection = false;
       if (e.key === 'ArrowLeft' && index > 0) {
         index -= 1;
         // When the activeElement GalleryItem goes out of view, focus will be handed over to the body element:
@@ -99,10 +100,18 @@ const Layout = ({ contentRect }: LayoutProps) => {
         if (!uiStore.isFileTagsEditorOpen && !uiStore.isFileExtraPropertiesEditorOpen) {
           FocusManager.focusGallery();
         }
+        // ctrl + space = jump to next single item, useful when using the file tag editor
+      } else if (e.key === ' ' && (e.metaKey || e.ctrlKey) && index < fileStore.fileList.length - 1) { // eslint-disable-line prettier/prettier
+        index += 1;
+        clearSelection = true;
       } else {
         return;
       }
-      handleFileSelect(fileStore.fileList[index], e.ctrlKey || e.metaKey, e.shiftKey);
+      handleFileSelect(
+        fileStore.fileList[index],
+        !clearSelection && (e.ctrlKey || e.metaKey),
+        !clearSelection && e.shiftKey,
+      );
     });
 
     const throttledKeyDown = throttle(onKeyDown, 50);

--- a/src/frontend/containers/ContentView/ListGallery.tsx
+++ b/src/frontend/containers/ContentView/ListGallery.tsx
@@ -1,4 +1,4 @@
-import { action } from 'mobx';
+import { action, runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React, {
   ForwardedRef,
@@ -19,6 +19,8 @@ import { useStore } from '../../contexts/StoreContext';
 import { ClientFile } from '../../entities/File';
 import { Row } from './ListItem';
 import { GalleryProps } from './utils';
+
+const SCROLL_PAGE_THRESHOLD = 50;
 
 /** Generates a unique key for an element in the fileList */
 const getItemKey = action((index: number, data: (ClientFile | undefined)[]): string => {
@@ -47,6 +49,39 @@ const ListGallery = observer(({ contentRect, select, lastSelectionIndex }: Galle
     return () => resizeObserver.disconnect();
   }, []);
 
+  const loadingPage = useRef<'after' | 'before' | null>(null);
+
+  useEffect(() => {
+    loadingPage.current = null;
+  }, [fileStore.fileList.length]);
+
+  const checkPagination = useCallback(() => {
+    const elem = list.current;
+    if (!elem) {
+      return;
+    }
+    const { scrollTop, scrollHeight, clientHeight } = elem;
+    const needsLoadNext = scrollTop + clientHeight >= scrollHeight - SCROLL_PAGE_THRESHOLD;
+    const needsLoadPrev = scrollTop <= SCROLL_PAGE_THRESHOLD;
+    if (needsLoadNext && loadingPage.current !== 'after') {
+      loadingPage.current = 'after';
+      fileStore.fetchAfter();
+    }
+    if (needsLoadPrev && loadingPage.current !== 'before') {
+      const firstItemId = runInAction(() => uiStore.firstFileInView?.id);
+      loadingPage.current = 'before';
+      fileStore.fetchBefore().then(() => {
+        if (!firstItemId) {
+          return;
+        }
+        const newIndex = fileStore.getIndex(firstItemId);
+        if (newIndex) {
+          ref.current?.scrollToItem(newIndex, 'smart');
+        }
+      });
+    }
+  }, [fileStore, uiStore.firstFileInView?.id]);
+
   const throttledScrollHandler = useRef(
     debouncedThrottle(
       action((index: number) => !uiStore.isSlideMode && uiStore.setFirstItem(index)),
@@ -55,9 +90,12 @@ const ListGallery = observer(({ contentRect, select, lastSelectionIndex }: Galle
   );
 
   const handleScroll = useCallback(
-    (props: ListOnScrollProps) =>
-      throttledScrollHandler.current(Math.round(props.scrollOffset / cellSize)),
-    [cellSize],
+    (props: ListOnScrollProps) => {
+      const currentIndex = Math.round(props.scrollOffset / cellSize);
+      throttledScrollHandler.current(currentIndex);
+      checkPagination();
+    },
+    [cellSize, checkPagination],
   );
 
   const index = lastSelectionIndex.current;

--- a/src/frontend/containers/ContentView/Masonry/MasonryRenderer.tsx
+++ b/src/frontend/containers/ContentView/Masonry/MasonryRenderer.tsx
@@ -115,6 +115,36 @@ const MasonryRenderer = observer(({ contentRect, select, lastSelectionIndex }: G
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Handle keyboard Control thumbnail size here since this componente renders masonry view
+  useEffect(() => {
+    const handleWheel = (e: WheelEvent) => {
+      if (e.ctrlKey) {
+        e.preventDefault();
+        // (e.deltaY > 0 = down, < 0 = up)
+        if (e.deltaY < 0) {
+          uiStore.setThumbnailSize((prev) => {
+            if (typeof prev !== 'number') {
+              return 368; // reset to medium
+            }
+            return prev + 20;
+          });
+        } else {
+          uiStore.setThumbnailSize((prev) => {
+            if (typeof prev !== 'number') {
+              return 368; // reset to medium
+            }
+            return prev - 20;
+          });
+        }
+      }
+    };
+
+    const throttledHandleWheel = throttle(handleWheel, 50);
+    window.addEventListener('wheel', throttledHandleWheel, { passive: false });
+    return () => window.removeEventListener('wheel', throttledHandleWheel);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Initialize on mount
   useEffect(() => {
     (async function onMount() {

--- a/src/frontend/containers/HelpCenter.tsx
+++ b/src/frontend/containers/HelpCenter.tsx
@@ -358,9 +358,10 @@ const PAGE_DATA: () => IPageData[] = () => [
               To organize your tags, simply drag the list items across the outliner. You can drop
               items onto one another to create a hierarchy. In this way you can turn a list of many
               tags into a structured shape, so that it is easy for you to find the specific tags you
-              were looking for. Alternatively, you can search for a tag in the File tags editor,
-              right-click the tag you're searching for, and select "Reveal in tags panel" to quickly
-              find a tag.
+              were looking for. Alternatively, you can search for a tag by clicking the magnifier
+              button at the header of the tags tree panel. You can also right-click any tag inside
+              the File tags editor or the assigned tags list and select "Reveal in tags panel" to
+              quickly find its location.
             </p>
             <p>
               You can set aliases, tag descriptions, implied relationships, and other settings for a
@@ -474,14 +475,34 @@ const PAGE_DATA: () => IPageData[] = () => [
         ),
       },
       {
+        title: 'Tag Palettes',
+        content: (
+          <>
+            <p>
+              Tag Palettes allow you to define restricted, custom lists of tags to avoid
+              interference from the rest of your tag library. This is especially useful when
+              classifying files within a predefined set of tags, keeping those specific tags
+              immediately available in the selector's base state without needing to type or search
+              for them, or search between them more efficiently.
+            </p>
+            <p>
+              To open the Tag Palettes manager, click the settings button located right above the
+              tag selectors, or use the shortcut "7". Inside the manager, you can create, rename,
+              delete, and reorder your palettes, as well as add and organize their respective tags.
+            </p>
+          </>
+        ),
+      },
+      {
         title: 'Navigation',
         content: (
           <>
             <p>
               When you have a large library of tags, it could be hard to find or remember where a
-              tag is in the hierarchy, in this case you can search for the tag on the tag editor
-              panel or in assigned tags in a file, and right-click them to show the option "Reveal
-              in tags panel" to quickly find a tag.
+              tag is in the hierarchy. In this case, you can search for the tag by clicking the
+              magnifier button at the header of the tags tree panel and typing a tag. You also can
+              use the tag editor panel or the assigned tags in a file by right-clicking them to show
+              the option "Reveal in tags panel" to quickly find a tag.
             </p>
           </>
         ),

--- a/src/frontend/containers/Inspector/index.tsx
+++ b/src/frontend/containers/Inspector/index.tsx
@@ -9,6 +9,7 @@ import { IS_PREVIEW_WINDOW } from 'common/window';
 import FileExtraPropertiesEditor from '../../components/FileExtraPropertiesEditor';
 import ExifViewer from 'src/frontend/components/ExifViewer';
 import { Thumbnail } from '../ContentView/GalleryItem';
+import TagSelectorSettingsButton from 'src/frontend/components/TagSelectorSettingsButton';
 
 const Inspector = observer(() => {
   const { uiStore, fileStore } = useStore();
@@ -71,6 +72,7 @@ const Inspector = observer(() => {
           </section>
           <section>
             <header>
+              <TagSelectorSettingsButton />
               <h2>Tags</h2>
             </header>
             <FileTags file={first} />

--- a/src/frontend/containers/Outliner/FileEditorsPanel/index.tsx
+++ b/src/frontend/containers/Outliner/FileEditorsPanel/index.tsx
@@ -19,6 +19,8 @@ const defaultPanel = {
   content: <></>,
 };
 
+export const FILE_EDITOR_HEADER_ID = 'file-editors-panel-header';
+
 const FileEditorsPanel = observer(({ className }: Partial<MultiSplitPaneProps>) => {
   const { uiStore } = useStore();
 
@@ -44,7 +46,7 @@ const FileEditorsPanel = observer(({ className }: Partial<MultiSplitPaneProps>) 
         content: (
           <FileExtraPropertiesEditor
             id="outliner-extra-porperties"
-            addButtonContainerID="file-editors-panel-header"
+            addButtonContainerID={FILE_EDITOR_HEADER_ID}
             menuPlacement="right-start"
           />
         ),

--- a/src/frontend/containers/Outliner/LocationsPanel/LocationPropertiesEditor.tsx
+++ b/src/frontend/containers/Outliner/LocationsPanel/LocationPropertiesEditor.tsx
@@ -90,6 +90,7 @@ export const LocationPropertiesEditor = observer(
                   onClear={locationToEdit.clearTags}
                   multiline
                   filter={(t) => !relatedTags.get().has(t)}
+                  clearInputOnSelect={false}
                 />
                 <br />
                 <br />

--- a/src/frontend/containers/Outliner/TagsPanel/SearchTagBar.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/SearchTagBar.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { TagSelector } from 'src/frontend/components/TagSelector';
+import { IconButton } from 'widgets/button';
+import { IconSet } from 'widgets/icons';
+import { TagsTreeItemRevealer } from './TagsTree';
+
+const SearchTagBar = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className={`search-tag-bar ${isExpanded ? 'expanded' : ''}`} data-tooltip={'Search a Tag'}>
+      <TagSelector
+        strat="fixed"
+        placement="right-start"
+        multiline={false}
+        selection={[]}
+        onDeselect={() => {}}
+        onSelect={(tag) => {
+          TagsTreeItemRevealer.instance.revealTag(tag);
+        }}
+        onClear={() => {
+          setIsExpanded((prev) => !prev);
+        }}
+        extraIconButtons={
+          <IconButton //
+            className="btn-icon-search"
+            icon={IconSet.SEARCH}
+            text="Search a Tag"
+            onClick={() => {
+              setIsExpanded((prev) => !prev);
+            }}
+          />
+        }
+      />
+    </div>
+  );
+};
+
+export default SearchTagBar;

--- a/src/frontend/containers/Outliner/TagsPanel/TagMerge.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagMerge.tsx
@@ -91,6 +91,7 @@ export const TagMerge = observer(() => {
             onDeselect={() => setSelectedTag(undefined)}
             onClear={() => setSelectedTag(undefined)}
             multiline
+            clearInputOnSelect={false}
           />
           {mergingWithSelf && (
             <span className="form-error">You cannot merge a tag with itself.</span>

--- a/src/frontend/containers/Outliner/TagsPanel/TagPaletteEditor.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagPaletteEditor.tsx
@@ -1,0 +1,251 @@
+import { observer } from 'mobx-react-lite';
+import React, { useRef, useState } from 'react';
+
+import { Button, IconSet } from 'widgets';
+import { Dialog } from 'widgets/popovers';
+import { useStore } from 'src/frontend/contexts/StoreContext';
+import { TagSelector } from 'src/frontend/components/TagSelector';
+import { Placement } from '@floating-ui/core';
+import { TagOrderEditor } from 'src/frontend/components/TagOrderEditor';
+import { runInAction } from 'mobx';
+import { ClientTagPalette } from 'src/frontend/entities/TagPalette';
+
+const FALLBACK_PLACEMENTS: Placement[] = ['top'];
+
+export const TagPaletteEditor = observer(() => {
+  const { uiStore, tagPaletteStore } = useStore();
+  const isOpen = uiStore.isTagPaletteEditorOpen;
+  const [selectedPaletteId, setSelectedPaletteId] = useState<string | undefined>(undefined);
+  const [draggedPaletteId, setDraggedPaletteId] = useState<string | null>(null);
+
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  const tagSelectorRef = useRef<HTMLInputElement>(null);
+
+  // Fallback to the first palette if the current selection becomes invalid or is empty
+  const activePalette =
+    tagPaletteStore.get(selectedPaletteId ?? '') ?? tagPaletteStore.paletteList.at(0);
+
+  const handleCreatePalette = async () => {
+    runInAction(async () => {
+      const baseName = 'New Tag Palette';
+      const existingPalettes = tagPaletteStore.paletteList.filter((p) =>
+        p.name.startsWith(baseName),
+      );
+      const targetName =
+        existingPalettes.length === 0 ? baseName : `${baseName} ${existingPalettes.length}`;
+      const newPalette = await tagPaletteStore.createPalette(targetName);
+      setSelectedPaletteId(newPalette.id);
+    });
+  };
+
+  const handleDeletePalette = (paletteToDelete: ClientTagPalette) =>
+    runInAction(async () => {
+      const list = tagPaletteStore.paletteList;
+      const currentIndex = list.findIndex((p) => p.id === paletteToDelete.id);
+      let nextPaletteId: string | undefined = undefined;
+
+      if (list.length > 1) {
+        const nextIndex = currentIndex === list.length - 1 ? currentIndex - 1 : currentIndex;
+        const remainingPalettes = list.filter((p) => p.id !== paletteToDelete.id);
+        nextPaletteId = remainingPalettes[nextIndex]?.id;
+      }
+
+      if (activePalette?.id === paletteToDelete.id) {
+        setSelectedPaletteId(nextPaletteId);
+      }
+
+      await tagPaletteStore.deletePalette(paletteToDelete);
+    });
+
+  ////////////// Drag ///////////
+
+  const handleDragStart = (id: string) => {
+    setDraggedPaletteId(id);
+  };
+
+  const handleDragOver = (e: React.DragEvent, targetIndex: number) => {
+    e.preventDefault();
+    if (draggedPaletteId === null) {
+      return;
+    }
+    const sourcePalette = tagPaletteStore.get(draggedPaletteId);
+    if (!sourcePalette) {
+      return;
+    }
+    const currentIndex = tagPaletteStore.findIndex(draggedPaletteId);
+    if (currentIndex !== -1 && currentIndex !== targetIndex) {
+      tagPaletteStore.reorderPalette(sourcePalette, targetIndex);
+    }
+  };
+
+  ///////////
+
+  return (
+    <Dialog
+      open={isOpen}
+      title="Manage Tag Palettes"
+      icon={IconSet.TAG_GROUP}
+      onCancel={uiStore.closeTagPaletteEditor}
+      className="tag-palette-dialog"
+    >
+      <div id="tag-palette-dialog-content">
+        {isOpen && (
+          <>
+            <div className="palette-sidebar">
+              <div className="sidebar-header">
+                <span>Palettes</span>
+                <button
+                  type="button"
+                  className="button is-compact"
+                  onClick={handleCreatePalette}
+                  title="Create new palette"
+                >
+                  {IconSet.ADD} Add
+                </button>
+              </div>
+
+              <div className="palette-vertical-list config-scrollbar">
+                {tagPaletteStore.isEmpty ? (
+                  <div className="empty-state">No palettes available</div>
+                ) : (
+                  tagPaletteStore.paletteList.map((palette, index) => {
+                    const isSelected = activePalette?.id === palette.id;
+                    const isDragging = draggedPaletteId === palette.id;
+
+                    return (
+                      <div
+                        key={palette.id}
+                        draggable
+                        onDragStart={() => handleDragStart(palette.id)}
+                        onDragOver={(e) => handleDragOver(e, index)}
+                        onDragEnd={() => setDraggedPaletteId(null)}
+                        onClick={() => setSelectedPaletteId(palette.id)}
+                        className={`palette-list-item ${isSelected ? 'is-selected' : ''} ${
+                          isDragging ? 'is-dragging' : ''
+                        }`}
+                      >
+                        <span className="palette-name">{palette.name}</span>
+
+                        <button
+                          type="button"
+                          className="delete-btn"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDeletePalette(palette);
+                          }}
+                          title="Delete palette"
+                        >
+                          {IconSet.DELETE}
+                        </button>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+
+            <div className="palette-main-editor" style={{ flex: 1 }}>
+              {activePalette ? (
+                <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+                  <legend
+                    className="dialog-section-label"
+                    style={{ marginBottom: '15px', fontWeight: 'bold' }}
+                  >
+                    Tag Palette Properties
+                  </legend>
+
+                  <label className="dialog-label">Palette Name</label>
+                  <input
+                    key={activePalette.id}
+                    ref={nameInputRef}
+                    className="input"
+                    autoFocus
+                    type="text"
+                    defaultValue={activePalette.name}
+                    onBlur={(e) => handleBlur(e, activePalette.rename)}
+                    onKeyDown={(e) => handleKeyDown(e, activePalette.rename)}
+                  />
+                  <br />
+                  <br />
+
+                  <label className="dialog-label">
+                    Search and append tags{' '}
+                    <span style={{ fontSize: '11px', opacity: 0.6 }}>
+                      (Click to select, drag to reorder)
+                    </span>
+                  </label>
+                  <br />
+                  <TagSelector
+                    ref={tagSelectorRef}
+                    fallbackPlacements={FALLBACK_PLACEMENTS}
+                    placement="top"
+                    disabled={false}
+                    selection={[]}
+                    onSelect={(tag) => {
+                      activePalette.addTag(tag);
+                    }}
+                    onDeselect={(tag) => activePalette.tags.remove(tag)}
+                    onClear={activePalette.clearTags}
+                    multiline
+                  />
+                  <br />
+                  <TagOrderEditor
+                    multiline
+                    selection={activePalette.tags}
+                    onMoveSelection={(selectedIndices, targetIndex) => {
+                      activePalette.moveTagsSelectionByIndices(selectedIndices, targetIndex);
+                    }}
+                    onRemoveTag={(_tag, index) => activePalette.removeTagAt(index)}
+                    onBackgroundClick={() => tagSelectorRef.current?.focus()}
+                  />
+                </fieldset>
+              ) : (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    opacity: 0.5,
+                  }}
+                >
+                  Select or create a palette from the sidebar to start editing.
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+      <div className="dialog-actions">
+        <Button text="Close" styling="filled" onClick={uiStore.closeTagPaletteEditor} />
+      </div>
+    </Dialog>
+  );
+});
+
+export default TagPaletteEditor;
+
+const handleBlur = (
+  e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement, Element>,
+  setFn: (value: string) => void,
+) => {
+  const value = e.currentTarget.value.trim();
+  if (value.length > 0) {
+    setFn(value);
+  }
+};
+
+const handleKeyDown = (
+  e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
+  setFn: (value: string) => void,
+) => {
+  e.stopPropagation();
+  const value = e.currentTarget.value.trim();
+  if (!e.shiftKey && e.key === 'Enter' && value.length > 0) {
+    setFn(value);
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    e.currentTarget.value = e.currentTarget.defaultValue;
+    e.currentTarget.blur();
+  }
+};

--- a/src/frontend/containers/Outliner/TagsPanel/TagPaletteEditor.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagPaletteEditor.tsx
@@ -104,7 +104,7 @@ export const TagPaletteEditor = observer(() => {
                 </button>
               </div>
 
-              <div className="palette-vertical-list config-scrollbar">
+              <div className="palette-vertical-list">
                 {tagPaletteStore.isEmpty ? (
                   <div className="empty-state">No palettes available</div>
                 ) : (
@@ -124,7 +124,9 @@ export const TagPaletteEditor = observer(() => {
                           isDragging ? 'is-dragging' : ''
                         }`}
                       >
-                        <span className="palette-name">{palette.name}</span>
+                        <span className="palette-name" title={palette.name}>
+                          {palette.name}
+                        </span>
 
                         <button
                           type="button"

--- a/src/frontend/containers/Outliner/TagsPanel/TagPropertiesEditor.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagPropertiesEditor.tsx
@@ -196,6 +196,7 @@ export const TagPropertiesEditor = observer(() => {
                 onClear={() => tag.replaceImpliedTags([])}
                 multiline
                 filter={(t) => !relatedTags.get().has(t)}
+                clearInputOnSelect={false}
               />
               <br />
               <label className="dialog-label" htmlFor="tag-implyBy-picker">
@@ -210,6 +211,7 @@ export const TagPropertiesEditor = observer(() => {
                 onClear={() => tag.replaceImpliedByTags([])}
                 multiline
                 filter={(t) => !relatedTags.get().has(t)}
+                clearInputOnSelect={false}
               />
             </fieldset>
           </>

--- a/src/frontend/containers/Outliner/TagsPanel/TagsMoveTo.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagsMoveTo.tsx
@@ -92,6 +92,7 @@ export const TagsMoveTo = observer(() => {
             onClear={() => setSelectedTag(undefined)}
             multiline
             filter={isMulti ? undefined : (t) => tag !== t && !t.isImpliedAncestor(tag)}
+            clearInputOnSelect={false}
           />
         </fieldset>
         <br />

--- a/src/frontend/containers/Outliner/TagsPanel/TagsTree.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagsTree.tsx
@@ -32,6 +32,7 @@ import { TagItemContextMenu } from './ContextMenu';
 import SearchButton from './SearchButton';
 import { Action, Factory, Flag, State, reducer } from './state';
 import { ID } from 'src/api/id';
+import SearchTagBar from './SearchTagBar';
 
 export class TagsTreeItemRevealer extends TreeItemRevealer {
   public static readonly instance: TagsTreeItemRevealer = new TagsTreeItemRevealer();
@@ -807,6 +808,7 @@ const TagsTree = observer((props: Partial<MultiSplitPaneProps>) => {
       }}
       headerToolbar={
         <Toolbar controls="tag-hierarchy" isCompact>
+          <SearchTagBar />
           {!tagStore.fileCountsInitialized && (
             <ToolbarButton
               icon={IconSet.RELOAD_COMPACT}

--- a/src/frontend/containers/Outliner/TagsPanel/index.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/index.tsx
@@ -12,6 +12,7 @@ import TagsTree from './TagsTree';
 import { TagPropertiesEditor } from './TagPropertiesEditor';
 import { TagsMoveTo } from './TagsMoveTo';
 import { TagMerge } from './TagMerge';
+import TagPaletteEditor from './TagPaletteEditor';
 
 // Tooltip info
 const enum TooltipInfo {
@@ -95,6 +96,7 @@ const TagsPanel = (props: Partial<MultiSplitPaneProps>) => {
       <TagPropertiesEditor />
       <TagMerge />
       <TagsMoveTo />
+      <TagPaletteEditor />
     </>
   );
 };

--- a/src/frontend/containers/Settings/UsagePreferences.tsx
+++ b/src/frontend/containers/Settings/UsagePreferences.tsx
@@ -85,7 +85,7 @@ export const UsagePreferences = observer(() => {
           checked={uiStore.isIncludeSubtagsOnMatchEnabled}
           onChange={uiStore.toggleIncludeSubtagsOnMatch}
         >
-          Include Sub-tags On Tag Selector Suggestion Matches
+          Include Sub-tags In Tag Selector Suggestion Matches
         </Toggle>
         <br />
         <div style={{ display: 'flex' }}>

--- a/src/frontend/entities/TagPalette.ts
+++ b/src/frontend/entities/TagPalette.ts
@@ -1,0 +1,132 @@
+import {
+  IObservableArray,
+  action,
+  IReactionDisposer,
+  makeObservable,
+  observable,
+  reaction,
+} from 'mobx';
+
+import { ID } from '../../api/id';
+import { ClientTag } from './Tag';
+import { TagPaletteDTO } from 'src/api/tagPalette';
+import TagPaletteStore from '../stores/TagPaletteStore';
+
+/**
+ * Represents a TagPalette object in the client-side MobX store.
+ */
+export class ClientTagPalette {
+  private store: TagPaletteStore;
+  private saveHandler: IReactionDisposer;
+
+  readonly id: ID;
+  @observable name: string = '';
+  @observable index: number;
+
+  /** An ordered array of client tag instances belonging to this palette (can contain duplicates) */
+  readonly tags: IObservableArray<ClientTag>;
+
+  constructor(store: TagPaletteStore, paletteProps: TagPaletteDTO) {
+    this.store = store;
+    this.id = paletteProps.id;
+    this.name = paletteProps.name;
+    this.index = paletteProps.index;
+
+    this.tags = observable(store.resolveTags(paletteProps.tags));
+
+    makeObservable(this);
+
+    // Observe all changes to observable fields and structure to trigger auto-save
+    this.saveHandler = reaction(
+      () => this.serialize(),
+      (serializedPalette) => {
+        this.store.save(serializedPalette);
+      },
+      { delay: 500 },
+    );
+  }
+
+  @action.bound rename(name: string): void {
+    this.name = name;
+  }
+
+  @action.bound clearTags(): void {
+    this.tags.replace([]);
+  }
+
+  @action.bound addTag(tag: ClientTag): void {
+    this.tags.push(tag);
+  }
+
+  /**
+   * Moves a specific tag instance from a source index to a destination index.
+   * This natively supports duplicate tags since it relies on array indices.
+   */
+  @action.bound moveTagAt(fromIndex: number, toIndex: number): boolean {
+    if (
+      fromIndex < 0 ||
+      fromIndex >= this.tags.length ||
+      toIndex < 0 ||
+      toIndex > this.tags.length ||
+      fromIndex === toIndex
+    ) {
+      return false;
+    }
+    const [tagToMove] = this.tags.splice(fromIndex, 1);
+    // If moving forward, the extraction shifts the items back, so adjust target index
+    const targetIndex = fromIndex < toIndex ? toIndex - 1 : toIndex;
+    this.tags.splice(targetIndex, 0, tagToMove);
+    return true;
+  }
+
+  @action.bound moveTagsSelectionByIndices(
+    selectedIndices: Set<number>,
+    targetIndex: number,
+  ): void {
+    const itemsToMove = this.tags.filter((_, idx) => selectedIndices.has(idx));
+    const remainingItems = this.tags.filter((_, idx) => !selectedIndices.has(idx));
+    const selectedBeforeTarget = Array.from(selectedIndices).filter(
+      (idx) => idx < targetIndex,
+    ).length;
+    const realTargetIndex = Math.max(0, targetIndex - selectedBeforeTarget);
+    const newOrder = [...remainingItems];
+    newOrder.splice(realTargetIndex, 0, ...itemsToMove);
+    this.tags.replace(newOrder);
+  }
+
+  /**
+   * Removes all occurrences of a specific tag reference from the palette.
+   */
+  @action.bound removeTagAllOccurrences(tag: ClientTag): void {
+    const filtered = this.tags.filter((t) => t !== tag);
+    this.tags.replace(filtered);
+  }
+
+  /**
+   * Removes a specific tag from the palette based on its unique position index.
+   */
+  @action.bound removeTagAt(index: number): boolean {
+    if (index >= 0 && index < this.tags.length) {
+      this.tags.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+
+  async delete(): Promise<void> {
+    return this.store.deletePalette(this);
+  }
+
+  serialize(): TagPaletteDTO {
+    return {
+      id: this.id,
+      name: this.name,
+      index: this.index,
+      tags: this.tags.map((tag) => tag.id),
+    };
+  }
+
+  dispose(): void {
+    this.saveHandler();
+  }
+}

--- a/src/frontend/hooks/useFocusEnforcer.ts
+++ b/src/frontend/hooks/useFocusEnforcer.ts
@@ -13,7 +13,7 @@ const useFocusEnforcer = ({
   isActive,
   ref,
   onFocusLost,
-  whitelistSelector = '[data-contextmenu="true"]',
+  whitelistSelector = '[data-contextmenu="true"], [data-popover="true"]',
 }: FocusOptions) => {
   const checkAndRestore = useCallback(() => {
     // request animation frame to allow the DOM to update focus

--- a/src/frontend/hooks/useHandleInputKeydown.ts
+++ b/src/frontend/hooks/useHandleInputKeydown.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react';
 import { comboMatches, getKeyCombo, parseKeyCombo } from '../hotkeyParser';
 import { useStore } from '../contexts/StoreContext';
 import { action } from 'mobx';
+import FocusManager from '../FocusManager';
 
 // A custom hook that returns a memoized callback to handle keydown events on
 // input elements, preventing interference from gallery navigation keyboard
@@ -33,14 +34,12 @@ export function useGalleryInputKeydownHandler() {
       e.preventDefault();
       return;
     }
-    if (e.altKey) {
+    if (e.altKey || (e.key === ' ' && (e.metaKey || e.ctrlKey))) {
       e.preventDefault();
       return;
     } else if (e.key === 'Escape') {
       e.preventDefault();
-      if (e.target instanceof HTMLInputElement) {
-        e.target.blur();
-      }
+      FocusManager.focusGallery();
     }
     // if Alt is not pressed, stop propagation to keep focus on the selected item.
     e.stopPropagation(); //Prevent event to propagate to the gallery

--- a/src/frontend/hooks/useScopeInteraction.ts
+++ b/src/frontend/hooks/useScopeInteraction.ts
@@ -102,6 +102,7 @@ const handleGlobalInteraction = (event: MouseEvent | FocusEvent) => {
   // Dispatch the event status to all active hook instances
   activeScopes.forEach((scope) => {
     if (!targetPath.startsWith(scope.currentPath)) {
+      //console.log('[onOutside] Target : ', target, 'CurrentPath: ', scope.currentPath, ' | Event: ', event.type); // eslint-disable-line prettier/prettier
       scope.onOutside?.(event);
     } else {
       scope.onInside?.(event);

--- a/src/frontend/hooks/useScopeInteraction.ts
+++ b/src/frontend/hooks/useScopeInteraction.ts
@@ -12,6 +12,7 @@ export interface ScopeInteractionProps {
 }
 
 export const INTERACTION_PATH_ATTRIBUTE_NAME = 'data-logical-path';
+export const INTERACTION_IGNORE_ATTRIBUTE_NAME = 'data-logical-ignore';
 
 /**
  * Hook to detect interactions (click or focus) outside of a conceptual/hierarchical element tree.
@@ -22,8 +23,8 @@ export const INTERACTION_PATH_ATTRIBUTE_NAME = 'data-logical-path';
  * It uses a prefix-based path matching (e.g., "menu" matches "menu/sub-menu/item-1").
  *
  * @param currentPath - Hierarchical path (e.g., "main-menu/option-1").
- * @param outsideCallback - Triggered when an interaction occurs outside the currentPath branch.
- * @param insideCallback - Triggered when an interaction occurs within the currentPath branch.
+ * @param onOutside - Triggered when an interaction occurs outside the currentPath branch.
+ * @param onInside - Triggered when an interaction occurs within the currentPath branch.
  * @param elementRef - Optional Ref to automatically assign the data-logical-path attribute.
  */
 export function useScopeInteraction({
@@ -32,39 +33,97 @@ export function useScopeInteraction({
   onInside,
   elementRef,
 }: ScopeInteractionProps) {
-  // Save the callback in refs to avoid unnesseesary redefine listener if the dev uses anonymous callbacks
-  const handlers = useRef({ onOutside, onInside });
-
+  // Keep mutable properties up to date without triggering effect cleanups
+  const handlers = useRef({ onOutside, onInside, currentPath });
   useEffect(() => {
-    handlers.current = { onOutside, onInside };
-  }, [onOutside, onInside]);
+    handlers.current = { onOutside, onInside, currentPath };
+  }, [onOutside, onInside, currentPath]);
 
+  // Synchronize the DOM attribute layout
   useEffect(() => {
     if (elementRef?.current) {
       elementRef.current.setAttribute(INTERACTION_PATH_ATTRIBUTE_NAME, currentPath);
     }
+  }, [currentPath, elementRef]);
 
-    const handleInteraction = (event: MouseEvent | FocusEvent) => {
-      // get the new focused or target element
-      const target = event.target as Element;
-      // search for any ancestor that is children of the current path
-      const interactiveEl = target.closest(`[${INTERACTION_PATH_ATTRIBUTE_NAME}]`);
-      const targetPath = interactiveEl?.getAttribute(INTERACTION_PATH_ATTRIBUTE_NAME) || '';
-
-      // if no match, or the path is not a children of the current path take it as a focus outside
-      if (!targetPath.startsWith(currentPath)) {
-        handlers.current.onOutside?.(event);
-      } else {
-        handlers.current.onInside?.(event);
-      }
+  // suscribe the handlers
+  useEffect(() => {
+    // use getters to return the current value from the ref
+    const scopeRegistration: ActiveScope = {
+      get currentPath() {
+        return handlers.current.currentPath;
+      },
+      get onOutside() {
+        return handlers.current.onOutside;
+      },
+      get onInside() {
+        return handlers.current.onInside;
+      },
     };
 
-    document.addEventListener('mousedown', handleInteraction);
-    document.addEventListener('focusin', handleInteraction);
+    activeScopes.add(scopeRegistration);
+    attachGlobalListeners();
 
     return () => {
-      document.removeEventListener('mousedown', handleInteraction);
-      document.removeEventListener('focusin', handleInteraction);
+      activeScopes.delete(scopeRegistration);
+      detachGlobalListeners(); // try to remove the global listener if no more scopes ares suscribed
     };
-  }, [currentPath, elementRef]);
+  }, []);
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////
+// Global event suscription handlers, to prevent event suscription spamming and easier debug.
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+interface ActiveScope {
+  currentPath: string;
+  onOutside?: (event: MouseEvent | FocusEvent) => void;
+  onInside?: (event: MouseEvent | FocusEvent) => void;
+}
+
+/** Stores all currently mounted hook instances */
+const activeScopes = new Set<ActiveScope>();
+
+const handleGlobalInteraction = (event: MouseEvent | FocusEvent) => {
+  const target = event.target as Element | undefined;
+  if (!target) {
+    return;
+  }
+  // Early exit if the target or any ancestor is explicitly marked to be ignored
+  if (target.closest(`[${INTERACTION_IGNORE_ATTRIBUTE_NAME}]`)) {
+    return;
+  }
+  // Query the DOM only ONCE per interaction event
+  const interactiveEl = target.closest(`[${INTERACTION_PATH_ATTRIBUTE_NAME}]`);
+  const targetPath = interactiveEl?.getAttribute(INTERACTION_PATH_ATTRIBUTE_NAME) || '';
+  // Debug
+  //console.log(`[ScopeInteraction] Target Path: "${targetPath}" | Event: ${event.type}`);
+
+  // Dispatch the event status to all active hook instances
+  activeScopes.forEach((scope) => {
+    if (!targetPath.startsWith(scope.currentPath)) {
+      scope.onOutside?.(event);
+    } else {
+      scope.onInside?.(event);
+    }
+  });
+};
+
+/** Track the global listener state */
+let globalListenersAttached = false;
+
+const attachGlobalListeners = () => {
+  if (!globalListenersAttached) {
+    document.addEventListener('mousedown', handleGlobalInteraction);
+    document.addEventListener('focusin', handleGlobalInteraction);
+    globalListenersAttached = true;
+  }
+};
+
+const detachGlobalListeners = () => {
+  if (globalListenersAttached && activeScopes.size === 0) {
+    document.removeEventListener('mousedown', handleGlobalInteraction);
+    document.removeEventListener('focusin', handleGlobalInteraction);
+    globalListenersAttached = false;
+  }
+};

--- a/src/frontend/stores/RootStore.ts
+++ b/src/frontend/stores/RootStore.ts
@@ -14,6 +14,7 @@ import { RendererMessenger } from 'src/ipc/renderer';
 import SearchStore from './SearchStore';
 import ExtraPropertyStore from './ExtraPropertyStore';
 import { AppToaster } from '../components/Toaster';
+import TagPaletteStore from './TagPaletteStore';
 
 // This will throw exceptions whenever we try to modify the state directly without an action
 // Actions will batch state modifications -> better for performance
@@ -36,6 +37,7 @@ class RootStore {
 
   readonly tagStore: TagStore;
   readonly extraPropertyStore: ExtraPropertyStore;
+  readonly tagPaletteStore: TagPaletteStore;
   readonly fileStore: FileStore;
   readonly locationStore: LocationStore;
   readonly uiStore: UiStore;
@@ -51,6 +53,7 @@ class RootStore {
   ) {
     this.tagStore = new TagStore(backend, this);
     this.extraPropertyStore = new ExtraPropertyStore(backend, this);
+    this.tagPaletteStore = new TagPaletteStore(backend, this);
     this.fileStore = new FileStore(backend, this);
     this.locationStore = new LocationStore(backend, this);
     this.uiStore = new UiStore(this);
@@ -82,6 +85,7 @@ class RootStore {
       // uses the location reference to set values.
       rootStore.locationStore.init(),
       rootStore.extraPropertyStore.init(),
+      rootStore.tagPaletteStore.init(),
       rootStore.exifTool.initialize(),
       rootStore.imageLoader.init(),
       rootStore.searchStore.init(),

--- a/src/frontend/stores/TagPaletteStore.ts
+++ b/src/frontend/stores/TagPaletteStore.ts
@@ -13,6 +13,8 @@ export class TagPaletteStore {
 
   private readonly palettesMap = observable(new Map<ID, ClientTagPalette>());
 
+  @observable activePallete: ClientTagPalette | undefined;
+
   constructor(backend: DataStorage, rootStore: RootStore) {
     this.backend = backend;
     this.rootStore = rootStore;
@@ -106,6 +108,10 @@ export class TagPaletteStore {
     palette.dispose();
     await this.backend.removeTagPalettes([palette.id]);
     this.normalizePaletteIndices();
+  }
+
+  @action.bound setActivePallete(pallete: ClientTagPalette | undefined): void {
+    this.activePallete = pallete;
   }
 
   save(paletteDto: TagPaletteDTO): void {

--- a/src/frontend/stores/TagPaletteStore.ts
+++ b/src/frontend/stores/TagPaletteStore.ts
@@ -1,0 +1,123 @@
+import { action, computed, makeObservable, observable, runInAction } from 'mobx';
+
+import { DataStorage } from '../../api/data-storage';
+import { generateId, ID } from '../../api/id';
+import { TagPaletteDTO } from 'src/api/tagPalette';
+import { ClientTag } from '../entities/Tag';
+import RootStore from './RootStore';
+import { ClientTagPalette } from '../entities/TagPalette';
+
+export class TagPaletteStore {
+  private readonly backend: DataStorage;
+  private readonly rootStore: RootStore;
+
+  private readonly palettesMap = observable(new Map<ID, ClientTagPalette>());
+
+  constructor(backend: DataStorage, rootStore: RootStore) {
+    this.backend = backend;
+    this.rootStore = rootStore;
+
+    makeObservable(this);
+  }
+
+  async init(): Promise<void> {
+    try {
+      const fetchedPalettes = await this.backend.fetchTagPalettes();
+      fetchedPalettes.sort((a, b) => a.index - b.index);
+      runInAction(() => {
+        for (const dto of fetchedPalettes) {
+          const palette = new ClientTagPalette(this, dto);
+          this.palettesMap.set(palette.id, palette);
+        }
+      });
+    } catch (err) {
+      console.error('Could not load tag palettes', err);
+    }
+  }
+
+  resolveTags(tagIds: ID[]): ClientTag[] {
+    return tagIds
+      .map((id) => this.rootStore.tagStore.get(id))
+      .filter((tag): tag is ClientTag => tag !== undefined);
+  }
+
+  @action get(id: ID): ClientTagPalette | undefined {
+    return this.palettesMap.get(id);
+  }
+
+  @action.bound findIndex(id: ID): number {
+    const pallete = this.palettesMap.get(id);
+    if (pallete) {
+      return pallete.index;
+    }
+    return -1;
+  }
+
+  @computed get paletteList(): readonly ClientTagPalette[] {
+    return Array.from(this.palettesMap.values()).sort((a, b) => a.index - b.index);
+  }
+
+  @computed get count(): number {
+    return this.palettesMap.size;
+  }
+
+  @computed get isEmpty(): boolean {
+    return this.count === 0;
+  }
+
+  @action.bound async createPalette(name: string): Promise<ClientTagPalette> {
+    const id = generateId();
+    const newPaletteDto: TagPaletteDTO = {
+      id,
+      name,
+      index: this.count, // Appends it to the end of the lists
+      tags: [],
+    };
+
+    const palette = new ClientTagPalette(this, newPaletteDto);
+
+    this.palettesMap.set(palette.id, palette);
+    await this.backend.createTagPalette(palette.serialize());
+    return palette;
+  }
+
+  @action.bound reorderPalette(paletteToMove: ClientTagPalette, targetIndex: number): void {
+    const currentList = [...this.paletteList];
+    const currentIndex = currentList.findIndex((p) => p.id === paletteToMove.id);
+    if (
+      currentIndex === -1 ||
+      targetIndex < 0 ||
+      targetIndex >= currentList.length ||
+      currentIndex === targetIndex
+    ) {
+      return;
+    }
+    currentList.splice(currentIndex, 1);
+    currentList.splice(targetIndex, 0, paletteToMove);
+    currentList.forEach((palette, idx) => {
+      if (palette.index !== idx) {
+        palette.index = idx;
+      }
+    });
+  }
+
+  @action.bound async deletePalette(palette: ClientTagPalette): Promise<void> {
+    this.palettesMap.delete(palette.id);
+    palette.dispose();
+    await this.backend.removeTagPalettes([palette.id]);
+    this.normalizePaletteIndices();
+  }
+
+  save(paletteDto: TagPaletteDTO): void {
+    this.backend.saveTagPalette(paletteDto);
+  }
+
+  @action private normalizePaletteIndices(): void {
+    let indexCounter = 0;
+    for (const palette of this.paletteList) {
+      palette.index = indexCounter++;
+    }
+  }
+}
+
+export default TagPaletteStore;

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -90,7 +90,7 @@ export interface IHotkeyMap {
   toggleExtraPropertiesEditor: string;
   toggleEditTagProperties: string;
   toggleLeftFileInfoViewer: string;
-  toggleTagPalletesEditor: string;
+  toggleTagPalettesEditor: string;
 
   toggleIncludeSubtagsOnTagSelectorSuggestionMatches: string;
 
@@ -107,7 +107,7 @@ export const defaultHotkeyMap: IHotkeyMap = {
   toggleEditTagProperties: '4',
   toggleExtraPropertiesEditor: '5',
   toggleLeftFileInfoViewer: '6',
-  toggleTagPalletesEditor: '7',
+  toggleTagPalettesEditor: '7',
   toggleIncludeSubtagsOnTagSelectorSuggestionMatches: 'shift + 3',
   replaceQuery: 'q',
   toggleSettings: 's',
@@ -258,7 +258,7 @@ class UiStore {
   @observable isFileTagsEditorOpen: boolean = false;
   @observable isFileExtraPropertiesEditorOpen: boolean = false;
   @observable isFileExifEditorOpen: boolean = false;
-  @observable isTagPaletteEditorOpen: boolean = true;
+  @observable isTagPaletteEditorOpen: boolean = false;
   /** Dialog for removing unlinked files from Allusion's database */
   @observable isToolbarFileRemoverOpen: boolean = false;
   /** Dialog for moving files to the system's trash bin, and removing from Allusion's database */
@@ -1494,7 +1494,7 @@ class UiStore {
       this.toggleFileExtraPropertiesEditor();
     } else if (matches(hotkeyMap.toggleLeftFileInfoViewer)) {
       this.toggleFileExtifEditor();
-    } else if (matches(hotkeyMap.toggleTagPalletesEditor)) {
+    } else if (matches(hotkeyMap.toggleTagPalettesEditor)) {
       this.toggleTagPaletteEditor();
     } else if (matches(hotkeyMap.toggleIncludeSubtagsOnTagSelectorSuggestionMatches)) {
       this.toggleIncludeSubtagsOnMatch();

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -90,6 +90,7 @@ export interface IHotkeyMap {
   toggleExtraPropertiesEditor: string;
   toggleEditTagProperties: string;
   toggleLeftFileInfoViewer: string;
+  toggleTagPalletesEditor: string;
 
   toggleIncludeSubtagsOnTagSelectorSuggestionMatches: string;
 
@@ -106,6 +107,7 @@ export const defaultHotkeyMap: IHotkeyMap = {
   toggleEditTagProperties: '4',
   toggleExtraPropertiesEditor: '5',
   toggleLeftFileInfoViewer: '6',
+  toggleTagPalletesEditor: '7',
   toggleIncludeSubtagsOnTagSelectorSuggestionMatches: 'shift + 3',
   replaceQuery: 'q',
   toggleSettings: 's',
@@ -256,6 +258,7 @@ class UiStore {
   @observable isFileTagsEditorOpen: boolean = false;
   @observable isFileExtraPropertiesEditorOpen: boolean = false;
   @observable isFileExifEditorOpen: boolean = false;
+  @observable isTagPaletteEditorOpen: boolean = true;
   /** Dialog for removing unlinked files from Allusion's database */
   @observable isToolbarFileRemoverOpen: boolean = false;
   /** Dialog for moving files to the system's trash bin, and removing from Allusion's database */
@@ -861,6 +864,20 @@ class UiStore {
 
   @action.bound closeFileExtifEditor(): void {
     this.isFileExifEditorOpen = false;
+  }
+
+  @action.bound toggleTagPaletteEditor(): void {
+    this.isTagPaletteEditorOpen = !this.isTagPaletteEditorOpen;
+  }
+
+  @action.bound openTagPaletteEditor(): void {
+    if (this.fileSelection.size > 0) {
+      this.isTagPaletteEditorOpen = true;
+    }
+  }
+
+  @action.bound closeTagPaletteEditor(): void {
+    this.isTagPaletteEditorOpen = false;
   }
 
   @action.bound openLocationRecovery(locationId: ID): void {
@@ -1477,6 +1494,8 @@ class UiStore {
       this.toggleFileExtraPropertiesEditor();
     } else if (matches(hotkeyMap.toggleLeftFileInfoViewer)) {
       this.toggleFileExtifEditor();
+    } else if (matches(hotkeyMap.toggleTagPalletesEditor)) {
+      this.toggleTagPaletteEditor();
     } else if (matches(hotkeyMap.toggleIncludeSubtagsOnTagSelectorSuggestionMatches)) {
       this.toggleIncludeSubtagsOnMatch();
     } else if (matches(hotkeyMap.toggleEditTagProperties)) {

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -92,7 +92,7 @@ export interface IHotkeyMap {
   toggleLeftFileInfoViewer: string;
   toggleTagPalettesEditor: string;
 
-  toggleIncludeSubtagsOnTagSelectorSuggestionMatches: string;
+  toggleIncludeSubtagsInTagSelectorSuggestionMatches: string;
 
   // Other
   openPreviewWindow: string;
@@ -108,7 +108,7 @@ export const defaultHotkeyMap: IHotkeyMap = {
   toggleExtraPropertiesEditor: '5',
   toggleLeftFileInfoViewer: '6',
   toggleTagPalettesEditor: '7',
-  toggleIncludeSubtagsOnTagSelectorSuggestionMatches: 'shift + 3',
+  toggleIncludeSubtagsInTagSelectorSuggestionMatches: 'shift + 3',
   replaceQuery: 'q',
   toggleSettings: 's',
   toggleHelpCenter: 'h',
@@ -1517,7 +1517,7 @@ class UiStore {
       this.toggleFileExtifEditor();
     } else if (matches(hotkeyMap.toggleTagPalettesEditor)) {
       this.toggleTagPaletteEditor();
-    } else if (matches(hotkeyMap.toggleIncludeSubtagsOnTagSelectorSuggestionMatches)) {
+    } else if (matches(hotkeyMap.toggleIncludeSubtagsInTagSelectorSuggestionMatches)) {
       this.toggleIncludeSubtagsOnMatch();
     } else if (matches(hotkeyMap.toggleEditTagProperties)) {
       this.toggleEditTagProperties();

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -201,6 +201,8 @@ class UiStore {
   static MIN_INSPECTOR_WIDTH = 288; // default of 18 rem
   static MAX_RECENTLY_USED_TAGS = 40;
   static MAX_TAGGING_SERVICE_PARALLEL_REQUESTS = 10;
+  static MIN_THUMBNAIL_SIZE = 128;
+  static MAX_THUMBNAIL_SIZE = 608;
 
   private readonly rootStore: RootStore;
 
@@ -385,12 +387,33 @@ class UiStore {
     return this.method === ViewMethod.MasonryHorizontal;
   }
 
-  @action.bound setThumbnailSize(size: ThumbnailSize): void {
-    if (typeof size === 'string' && !ThumbnailSizes.includes(size)) {
-      console.warn(size, '- Invalid thumbnailSize value, keeping previous value');
+  @action.bound setThumbnailSize(
+    value: ThumbnailSize | ((prev: ThumbnailSize) => ThumbnailSize),
+  ): void {
+    if (typeof value === 'string' && !ThumbnailSizes.includes(value)) {
+      console.warn(value, '- Invalid thumbnailSize value, keeping previous value');
       return;
     }
-    this.thumbnailSize = size;
+    let nextValue: ThumbnailSize = typeof value === 'function' ? value(this.thumbnailSize) : value;
+    if (typeof nextValue === 'number') {
+      nextValue = clamp(nextValue, UiStore.MIN_THUMBNAIL_SIZE, UiStore.MAX_THUMBNAIL_SIZE);
+    }
+    this.thumbnailSize = nextValue;
+    if (typeof nextValue === 'number') {
+      const percentage = Math.round(
+        ((nextValue - UiStore.MIN_THUMBNAIL_SIZE) /
+          (UiStore.MAX_THUMBNAIL_SIZE - UiStore.MIN_THUMBNAIL_SIZE)) *
+          100,
+      );
+      AppToaster.show(
+        {
+          message: `Thumbnail: ${percentage}%`,
+          timeout: 600,
+          compact: true,
+        },
+        'thumbnail-size',
+      );
+    }
   }
 
   @action.bound setThumbnailRadius(size: number): void {

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -871,9 +871,7 @@ class UiStore {
   }
 
   @action.bound openTagPaletteEditor(): void {
-    if (this.fileSelection.size > 0) {
-      this.isTagPaletteEditorOpen = true;
-    }
+    this.isTagPaletteEditorOpen = true;
   }
 
   @action.bound closeTagPaletteEditor(): void {

--- a/widgets/menus/ContextMenu.tsx
+++ b/widgets/menus/ContextMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { usePopover } from '../popovers/usePopover';
 import { Menu, MenuProps } from './menus';
+import { INTERACTION_IGNORE_ATTRIBUTE_NAME } from 'src/frontend/hooks/useScopeInteraction';
 
 export const ContextMenuLayer = ({ children }: { children: React.ReactNode }) => {
   const [state, setState] = useState({ isOpen: false, x: 0, y: 0, menu: <Menu>{[]}</Menu> });
@@ -112,6 +113,7 @@ const ContextMenu = ({ isOpen, x, y, children, close }: ContextMenuProps) => {
       data-popover
       data-open={isOpen}
       data-contextmenu
+      {...{ [INTERACTION_IGNORE_ATTRIBUTE_NAME]: true }}
       tabIndex={-1}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}

--- a/widgets/menus/MenuButton.tsx
+++ b/widgets/menus/MenuButton.tsx
@@ -16,6 +16,7 @@ export interface MenuButtonProps {
   placement?: Placement;
   strategy?: Strategy;
   updateDependency?: any;
+  title?: string;
 }
 
 export const MenuButton = ({
@@ -30,6 +31,7 @@ export const MenuButton = ({
   placement = 'bottom',
   strategy,
   updateDependency = children,
+  title,
 }: MenuButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const menu = useRef<HTMLUListElement>(null);
@@ -87,6 +89,7 @@ export const MenuButton = ({
         aria-disabled={disabled}
         data-collapsible={isCollapsible ?? true}
         data-tooltip={tooltip ?? text}
+        title={title}
         onClick={disabled ? undefined : () => setIsOpen(!isOpen)}
         aria-expanded={isOpen}
         aria-controls={menuID}

--- a/widgets/menus/menu-items.tsx
+++ b/widgets/menus/menu-items.tsx
@@ -134,7 +134,12 @@ export const MenuSliderItem = ({
   );
 };
 
-export const MenuDivider = () => <li role="separator" className="menu-separator"></li>;
+//export const MenuDivider = () => <li role="separator" className="menu-separator"></li>;
+export const MenuDivider = ({ label }: { label?: string }) => (
+  <li role="separator" className="menu-separator separator-container">
+    {label ? <div className="separator-label">{label}</div> : null}
+  </li>
+);
 
 export type MenuItemLinkProps = {
   icon?: JSX.Element;

--- a/widgets/menus/menus.tsx
+++ b/widgets/menus/menus.tsx
@@ -213,7 +213,9 @@ function handleMenuKeyDown(event: React.KeyboardEvent) {
   if (event.key === 'Enter') {
     if ((event.target as HTMLElement).matches('[role^="menuitem"]')) {
       event.stopPropagation();
-      (event.target as HTMLElement).click();
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => (event.target as HTMLElement).click()),
+      );
     }
   } else if (event.key === 'ArrowUp') {
     let listItem = (event.target as HTMLElement).closest('li') as HTMLElement | null;

--- a/widgets/notifications/Toast.tsx
+++ b/widgets/notifications/Toast.tsx
@@ -8,11 +8,12 @@ interface IToast {
   timeout: number;
   onDismiss: () => void;
   type?: 'info' | 'success' | 'warning' | 'error';
+  compact?: boolean;
 }
 
-export const Toast = ({ message, clickAction, onDismiss, type = "info" }: IToast) => {
+export const Toast = ({ message, clickAction, onDismiss, type = 'info', compact }: IToast) => {
   return (
-    <div className={`toast toast-${type}`}>
+    <div className={`toast toast-${type} ${compact ? 'compact' : ''}`}>
       <span>{message}</span>
       {clickAction}
       <Button text="Dismiss" onClick={onDismiss} />

--- a/widgets/toolbar.tsx
+++ b/widgets/toolbar.tsx
@@ -62,6 +62,7 @@ interface ToolbarButtonProps {
   checked?: boolean;
   controls?: string;
   type?: 'button' | 'submit' | 'reset';
+  title?: string;
 }
 
 const ToolbarButton = (props: ToolbarButtonProps) => {
@@ -78,6 +79,7 @@ const ToolbarButton = (props: ToolbarButtonProps) => {
     controls,
     tabIndex,
     type,
+    title,
   } = props;
   return (
     <button
@@ -91,6 +93,7 @@ const ToolbarButton = (props: ToolbarButtonProps) => {
       aria-controls={controls}
       tabIndex={tabIndex} // FIXME: Implement toolbar keyboard navigation.
       data-tooltip={tooltip ?? text}
+      title={title}
       type={type}
     >
       {icon}


### PR DESCRIPTION
### New Features
- Add the Tag Palettes feature.
  - Tag Palettes allow you to define custom lists of tags to avoid interference from the rest of your tag library. This is especially useful when classifying files with a predefined set of tags.
  - Add the Tag Palette Manager to create, delete, sort, and modify Tag Palettes.
- Add a settings button to file tag selectors for easy access to the most used tag selector settings.
- Add a quick search bar to the tags tree panel. 
  - Clicking the search icon expands the tag search input within the panel header.
- Add a navigation shortcut to select the next item using Ctrl+Space, useful when using the file tags editor.
- Allow controlling thumbnail size with Ctrl + mouse wheel. #147
- Add the ability to copy the filename (without extension) to the clipboard when clicking the file's thumbnail name.

### Fixes
- Fix a bug where modals were immediately closed when opened from a context menu using Enter.
- Fix a bug where the file tag editor's context menus immediately closed it due to incorrect onBlur handling. #146
- Fix a bug where the Escape key was not closing floating panels. #145 
- Fix an issue where pagination was not working in the list view. #143